### PR TITLE
had to add line to get mean stack working on my mac: enable node to server bower components

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -19,7 +19,8 @@ module.exports = function (app, config, passport) {
   }))
   app.use(express.favicon())
   app.use(express.static(config.root + '/public'))
-
+  app.use('/lib', express.static(config.root + '/bower_components'))
+  
   // don't use logger for test env
   if (process.env.NODE_ENV !== 'test') {
     app.use(express.logger('dev'))


### PR DESCRIPTION
The default app tries to load bower_components from /lib/[component]. They weren't set up to be served, so I had to add the following line to express.js:
- app.use('/lib', express.static(config.root + '/bower_components'))

FYI, this was my first time working with a lot of this stuff, so this might not have been the most efficient solution to getting the project working on my computer.
