### PR TITLE
Use twitter.id_str instead of twitter.id in twitter strategy

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -56,7 +56,7 @@ module.exports = function(passport, config) {
         },
         function(token, tokenSecret, profile, done) {
             User.findOne({
-                'twitter.id': profile.id
+                'twitter.id_str': profile.id
             }, function(err, user) {
                 if (err) {
                     return done(err);


### PR DESCRIPTION
I think we need to use twitter.id_str instead of twitter.id because profile.id is now returned as a string explicitly by the following change.

https://github.com/jaredhanson/passport-twitter/commit/d9112c4c0575c64243692a732c2590e8d158bdcf
