### PR TITLE
use Google OAuth2Strategy to avoid the error that key $t must not start with '$'

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -3,7 +3,7 @@ var mongoose = require('mongoose'),
     TwitterStrategy = require('passport-twitter').Strategy,
     FacebookStrategy = require('passport-facebook').Strategy,
     GitHubStrategy = require('passport-github').Strategy,
-    GoogleStrategy = require('passport-google-oauth').Strategy,
+    GoogleStrategy = require('passport-google-oauth').OAuth2Strategy,
     User = mongoose.model('User');
 
 
@@ -142,8 +142,8 @@ module.exports = function(passport, config) {
 
     //Use google strategy
     passport.use(new GoogleStrategy({
-            consumerKey: config.google.clientID,
-            consumerSecret: config.google.clientSecret,
+            clientID: config.google.clientID,
+            clientSecret: config.google.clientSecret,
             callbackURL: config.google.callbackURL
         },
         function(accessToken, refreshToken, profile, done) {

--- a/config/routes.js
+++ b/config/routes.js
@@ -44,11 +44,13 @@ module.exports = function(app, passport, auth) {
     //Setting the google oauth routes
     app.get('/auth/google', passport.authenticate('google', {
         failureRedirect: '/signin',
-        scope: 'https://www.google.com/m8/feeds'
+        scope: [
+          'https://www.googleapis.com/auth/userinfo.profile',
+          'https://www.googleapis.com/auth/userinfo.email'
+        ]
     }), users.signin);
     app.get('/auth/google/callback', passport.authenticate('google', {
-        failureRedirect: '/signin',
-        scope: 'https://www.google.com/m8/feeds'
+        failureRedirect: '/signin'
     }), users.authCallback);
 
     //Finish with setting up the userId param


### PR DESCRIPTION
" key $t must not start with '$' " error has occured when I signed in with google, because mongodb does not seem to support such value.

Using oauth2 is the good way to avoid this error according to the following discussion. I also confirmed the above error had no longer occured with this fix in my env.

https://github.com/madhums/node-express-mongoose-demo/issues/30

thanks!
