### PR TITLE
Updated authorization.js redirect

### DIFF
--- a/config/middlewares/authorization.js
+++ b/config/middlewares/authorization.js
@@ -3,7 +3,7 @@
  */
 exports.requiresLogin = function(req, res, next) {
     if (!req.isAuthenticated()) {
-        return res.redirect('/login');
+        return res.redirect('/');
     }
     next();
 };


### PR DESCRIPTION
The authorization.js redirect here sends people to '/login', which doesn't exist. I changed this to point to '/'.
