### PR TITLE
Remove "Requirements for Grunt from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,9 @@ MEAN is a boilerplate that provides a nice starting point for [MongoDB](http://w
 * MongoDB - Download and Install [MongoDB](http://www.mongodb.org/downloads) - Make sure it's running on the default port (27017).
 
 ### Optional
+* Ruby - Download and Install [Ruby](http://www.ruby-lang.org/).
+* Ruby Gems - Download and Install [Ruby Gems](http://rubygems.org).
+* Compass - an open-source CSS Authoring Framework, install via [Ruby Gems](http://rubygems.org).
 * Grunt - Download and Install [Grunt](http://gruntjs.com).
 
 ## Additional Packages


### PR DESCRIPTION
Having this in the title gives the impression that all these things are necessary for Grunt.  This is not the case because Ruby, Gems, and Compass are only truly needed for the Gruntfile.js contained in the repository not for Grunt itself.

On another note perhaps Compass/Ruby/Gems should all be removed since they are more a peripheral for the MEAN stack?  They aren't a core piece.  Perhaps styling should be left to the end user.  Perhaps they want to use LESS rather than SASS? 
