### PR TITLE
Replaced SHA1 password hashing with bcrypt in Local Passport authentication

### DIFF
--- a/app/models/user.js
+++ b/app/models/user.js
@@ -3,7 +3,7 @@
  */
 var mongoose = require('mongoose'),
     Schema = mongoose.Schema,
-    crypto = require('crypto'),
+    bcrypt = require('bcrypt'),
     _ = require('underscore'),
     authTypes = ['github', 'twitter', 'facebook', 'google'];
 
@@ -17,7 +17,6 @@ var UserSchema = new Schema({
     username: String,
     provider: String,
     hashed_password: String,
-    salt: String,
     facebook: {},
     twitter: {},
     github: {},
@@ -29,7 +28,6 @@ var UserSchema = new Schema({
  */
 UserSchema.virtual('password').set(function(password) {
     this._password = password;
-    this.salt = this.makeSalt();
     this.hashed_password = this.encryptPassword(password);
 }).get(function() {
     return this._password;
@@ -92,17 +90,7 @@ UserSchema.methods = {
      * @api public
      */
     authenticate: function(plainText) {
-        return this.encryptPassword(plainText) === this.hashed_password;
-    },
-
-    /**
-     * Make salt
-     *
-     * @return {String}
-     * @api public
-     */
-    makeSalt: function() {
-        return Math.round((new Date().valueOf() * Math.random())) + '';
+        return bcrypt.compareSync(plainText,this.hashed_password);
     },
 
     /**
@@ -114,7 +102,7 @@ UserSchema.methods = {
      */
     encryptPassword: function(password) {
         if (!password) return '';
-        return crypto.createHmac('sha1', this.salt).update(password).digest('hex');
+        return bcrypt.hashSync(password, 10);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
         "forever": "latest",
         "grunt": "latest",
         "grunt-cli": "latest",
-        "grunt-bower-task": "latest"
+        "grunt-bower-task": "latest",
+        "bcrypt": "latest"
     },
     "devDependencies": {
         "supertest": "latest",


### PR DESCRIPTION
Updating the local authentication strategy to use bcrypt rather than SHA1, per many articles advising against the use of SHA1 to store passwords, even with a salt, such as [this one on how to safely store a password](http://codahale.com/how-to-safely-store-a-password/). 

Eliminated the makeSalt function, since it could be done in a single command with bcrypt, in addition to getting rid of the salt field which is concatenated in the hashed password field itself. 
