### PR TITLE
Removed livereload from prod

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -28,5 +28,6 @@ script(type='text/javascript', src='js/controllers/index.js')
 script(type='text/javascript', src='js/controllers/header.js')	
 script(type='text/javascript', src='js/init.js')
 
-//Livereload script rendered 
-script(type='text/javascript', src='http://localhost:35729/livereload.js')	
+if (req.host='localhost')
+    //Livereload script rendered 
+    script(type='text/javascript', src='http://localhost:35729/livereload.js')	


### PR DESCRIPTION
Used if statement in app/views/includes/foot.jade to remove livereload js call from production environment
