### PR TITLE
fix port binding error when deploy to heroku

### DIFF
--- a/server.js
+++ b/server.js
@@ -50,7 +50,7 @@ require('./config/express')(app, passport);
 require('./config/routes')(app, passport, auth);
 
 //Start the app by listening on <port>
-var port = config.port;
+var port = process.env.PORT || config.port;
 app.listen(port);
 console.log('Express app started on port ' + port);
 


### PR DESCRIPTION
I tried to deploy mean to heroku but return R10 (Boot timeout) error,
then I found [this article](http://www.vibesphere.com/2013/06/gotchas-for-node-js-apps-on-heroku/) meet the same error and explain the reason of R10.

> when on Heroku, port will be exported to an environment variable and available as process.env.PORT

So I guess it would be better use process.env.PORT as default to make mean work fine after deploy to heroku.
