### PR TITLE
Fixed support for Passport Google with OAuth2

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -3,7 +3,7 @@ var mongoose = require('mongoose'),
     TwitterStrategy = require('passport-twitter').Strategy,
     FacebookStrategy = require('passport-facebook').Strategy,
     GitHubStrategy = require('passport-github').Strategy,
-    GoogleStrategy = require('passport-google-oauth').Strategy,
+    GoogleStrategy = require('passport-google-oauth').OAuth2Strategy,
     User = mongoose.model('User'),
     config = require('./config');
 
@@ -143,8 +143,8 @@ module.exports = function(passport) {
 
     //Use google strategy
     passport.use(new GoogleStrategy({
-            consumerKey: config.google.clientID,
-            consumerSecret: config.google.clientSecret,
+            clientID: config.google.clientID,
+            clientSecret: config.google.clientSecret,
             callbackURL: config.google.callbackURL
         },
         function(accessToken, refreshToken, profile, done) {


### PR DESCRIPTION
Updated passport-google-oauth to pass in the right configuration settings to passport for OAuth2 support, per documentation on https://github.com/jaredhanson/passport-google-oauth. 
