### PR TITLE
remove unnecessary query param from find function

### DIFF
--- a/public/js/controllers/articles.js
+++ b/public/js/controllers/articles.js
@@ -36,8 +36,8 @@ angular.module('mean.articles').controller('ArticlesController', ['$scope', '$ro
         });
     };
 
-    $scope.find = function(query) {
-        Articles.query(query, function(articles) {
+    $scope.find = function() {
+        Articles.query(function(articles) {
             $scope.articles = articles;
         });
     };


### PR DESCRIPTION
'query' parameter for find function is unnecessary in this case. Removed because it's confusing to users trying to learn MEAN from this project.
