### PR TITLE
Improved model autoload regex

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ var walk = function(path) {
         var newPath = path + '/' + file;
         var stat = fs.statSync(newPath);
         if (stat.isFile()) {
-            if (/(.*)\.(js|coffee)/.test(file)) {
+            if (/(.*)\.(js$|coffee$)/.test(file)) {
                 require(newPath);
             }
         } else if (stat.isDirectory()) {


### PR DESCRIPTION
Adding the end of line marker should make the model autoload regex not match files that have stuff after the extension, like `*.jswhatever` or `.js.swp`
