### PR TITLE
Bootstrap template dependency fix

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -4,8 +4,8 @@ script(type='text/javascript', src='/lib/angular-cookies/angular-cookies.js')
 script(type='text/javascript', src='/lib/angular-resource/angular-resource.js')
 
 //Angular UI
-script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap-tpls.js')
 script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap.js')
+script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap-tpls.js')
 script(type='text/javascript', src='/lib/angular-ui-utils/modules/route/route.js')
 
 //Application Init


### PR DESCRIPTION
After switching of order these two lines, you are now able to use features from Angular Bootstrap UI, for example: ui.bootstrap.popover... Without fix there is a error raised caused by missing bootstrap dependency.
