### PR TITLE
getting latest versions of bower packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 .nodemonignore
 .sass-cache/

--- a/bower.json
+++ b/bower.json
@@ -2,11 +2,18 @@
     "name": "mean",
     "version": "0.1.0",
     "dependencies": {
-        "bootstrap": "2.3.2",
-        "angular": "1.0.6",
-        "angular-resource": "1.0.6",
-        "angular-cookies": "1.0.6",
-        "angular-bootstrap": "0.6.0",
-        "angular-ui-utils": "0.0.4"
+        "angular": "latest",
+        "angular-cookies": "latest",
+        "angular-resource": "latest",
+        "angular-route": "latest",
+        "angular-sanitize": "latest",
+
+        "bootstrap": "latest",
+        "angular-bootstrap": "latest",
+        "angular-ui-utils": "latest"
+    },
+    "devDependencies": {
+        "angular-mocks": "latest",
+        "angular-scenario": "latest"
     }
 }


### PR DESCRIPTION
Updated bower.json to get the latests versions of the bower packages in the same way of package.json for node packages.

.gitignore was also updated to ignore .idea folder (Webstorm).
