### PR TITLE
Don't overwrite statics

### DIFF
--- a/app/models/article.js
+++ b/app/models/article.js
@@ -40,12 +40,10 @@ ArticleSchema.path('title').validate(function(title) {
 /**
  * Statics
  */
-ArticleSchema.statics = {
-    load: function(id, cb) {
-        this.findOne({
-            _id: id
-        }).populate('user', 'name username').exec(cb);
-    }
+ArticleSchema.statics.load = function(id, cb) {
+    this.findOne({
+        _id: id
+    }).populate('user', 'name username').exec(cb);
 };
 
 mongoose.model('Article', ArticleSchema);


### PR DESCRIPTION
Many plugins will add to the statics, by overwriting this method you're setting an easy trap to fall into.  It's better to just add an single name statics instead.
