### PR TITLE
Fix bug in foot.jade which tries to assign host instead of comparing it

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -24,6 +24,6 @@ script(type='text/javascript', src='/js/controllers/index.js')
 script(type='text/javascript', src='/js/controllers/header.js')	
 script(type='text/javascript', src='/js/init.js')
 
-if (req.host='localhost')
+if ('localhost' == req.host)
     //Livereload script rendered 
     script(type='text/javascript', src='http://localhost:35729/livereload.js')	


### PR DESCRIPTION
Fix missing equal sign in comparison. Moved the literal part to the front of the comparison (a good practice to avoid this)
