### PR TITLE
specify last working jade version to fix error

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     },
     "dependencies": {
         "express": "latest",
-        "jade": "latest",
+        "jade": "0.35.0",
         "mongoose": "latest",
         "connect-mongo": "latest",
         "connect-flash": "latest",


### PR DESCRIPTION
Jade's latest version introduces error in MEAN stack.  Specifying the last working version of Jade fixes this.
