### PR TITLE
correct the livereload host

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -27,4 +27,4 @@ script(type='text/javascript', src='/js/init.js')
 
 if (process.env.NODE_ENV == 'development')
     //Livereload script rendered
-    script(type='text/javascript', src='http://localhost:35729/livereload.js')
+    script(type='text/javascript', src='http://'+req.host+':35729/livereload.js')


### PR DESCRIPTION
This let's you use an arbitrary host in development mode, and do cross machine/VM testing etc, with a hostname other than localhost
