### PR TITLE
update gruntfile.js to let jshint adhere to .jshintrc

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -30,7 +30,12 @@ module.exports = function(grunt) {
             }
         },
         jshint: {
-            all: ['gruntfile.js', 'public/js/**/*.js', 'test/mocha/**/*.js', 'test/karma/**/*.js', 'app/**/*.js']
+            all: {
+                src: ['gruntfile.js', 'public/js/**/*.js', 'test/mocha/**/*.js', 'test/karma/**/*.js', 'app/**/*.js'],
+                options: {
+                    jshintrc: true
+                }
+            }
         },
         nodemon: {
             dev: {


### PR DESCRIPTION
currently the `jshint:all` task doesn't take the .jshintrc-file into account. This pull corrects that.
