### PR TITLE
Fixed 'unexpected text' error

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -25,6 +25,6 @@ script(type='text/javascript', src='/js/controllers/index.js')
 script(type='text/javascript', src='/js/controllers/header.js')
 script(type='text/javascript', src='/js/init.js')
 
+//Livereload script rendered
 if (process.env.NODE_ENV == 'development')
-    //Livereload script rendered
     script(type='text/javascript', src='http://' + req.host + ':35729/livereload.js')


### PR DESCRIPTION
The error could have also probably been fixed by adding { } to the if statement (line 29)

Also, I don't think JShint should be run on this, it's a jade template file.
