### PR TITLE
replace deprecated grunt-nodemon debug option

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -46,7 +46,7 @@ module.exports = function(grunt) {
                     args: [],
                     ignoredFiles: ['public/**'],
                     watchedExtensions: ['js'],
-                    debug: true,
+                    nodeArgs: ['--debug'],
                     delayTime: 1,
                     env: {
                         PORT: 3000


### PR DESCRIPTION
Since grunt-nodemon version 0.1.0 the debug option is deprecated and must
be replaced by a nodeArgs option.
