### PR TITLE
Changed syntax for including code for lt IE 9

### DIFF
--- a/app/views/includes/head.jade
+++ b/app/views/includes/head.jade
@@ -25,5 +25,6 @@ head
 
   link(rel='stylesheet', href='/css/views/articles.css')
 
-  //if lt IE 9
-    script(src='http://html5shim.googlecode.com/svn/trunk/html5.js')
+  <!--[if lt IE 9 ]>
+  script(src='http://html5shim.googlecode.com/svn/trunk/html5.js')
+  <![endif]-->


### PR DESCRIPTION
Since version 1.0.0, Jade does not parse comments content anymore, which means that _//if lt IE 7_ no longer will work. The change reflects the new, recommended way of including conditionals.
