### PR TITLE
Enabling to load MongoLab env

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -6,7 +6,7 @@ var rootPath = path.normalize(__dirname + '/../..');
 module.exports = {
 	root: rootPath,
 	port: process.env.PORT || 3000,
-	db: process.env.MONGOHQ_URL,
+	db: process.env.MONGOHQ_URL || process.env.MONGOLAB_URI,
 
 	// The secret should be set to a non-guessable string that
 	// is used to compute a session hash


### PR DESCRIPTION
Heroku offers two data store services for Mongo, MongoHQ and MongoLab.

This commit enables to use MongoLab service for the kinds of alternative for MongoHQ
