### PR TITLE
Updated production.js, resolve issue #260.

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    db: "mongodb://localhost/mean",
+    db: process.env.MONGOHQ_URL,
     app: {
         name: "MEAN - A Modern Stack - Production"
     },


### PR DESCRIPTION
Resolves issue #260. cannot connect to mongohq_URL otherwise. 

Originally, you get this error on heroku: Error: failed to connect to [localhost:27017]

But with this update, it'll connect to mongohq on heroku server.
