### PR TITLE
Added Linkedin To Test Env

### DIFF
--- a/config/env/test.js
+++ b/config/env/test.js
@@ -25,5 +25,10 @@ module.exports = {
         clientID: "APP_ID",
         clientSecret: "APP_SECRET",
         callbackURL: "http://localhost:3000/auth/google/callback"
+    },
+    linkedin: {
+        clientID: "APP_ID",
+        clientSecret: "APP_SECRET",
+        callbackURL: "http://localhost:3000/auth/linkedin/callback"
     }
 }


### PR DESCRIPTION
Simply added the default  linked in option to the testing environment.  It now matches the production.js and development.js environments.
