### PR TITLE
Update gruntfile.js to remove test/coverage directory from jshint config...

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
         },
         jshint: {
             all: {
-                src: ['gruntfile.js', 'server.js', 'app/**/*.js', 'public/js/**', 'test/**/*.js'],
+                src: ['gruntfile.js', 'server.js', 'app/**/*.js', 'public/js/**', 'test/**/*.js', '!test/coverage/**/*.js'],
                 options: {
                     jshintrc: true
                 }


### PR DESCRIPTION
When we launch grunt test task, grunt create test/coverage directory with minified js code. So this code should be remove from jshint task config.
