### PR TITLE
this resolves issue #260. removed db reference from all.js and added mon...

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -6,7 +6,6 @@ var rootPath = path.normalize(__dirname + '/../..');
 module.exports = {
 	root: rootPath,
 	port: process.env.PORT || 3000,
-	db: process.env.MONGOHQ_URL,
 	templateEngine: 'swig',
 
 	// The secret should be set to a non-guessable string that

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-    db: 'mongodb://localhost/mean',
+    db: 'process.env.MONGOHQ_URL',
     app: {
         name: 'MEAN - A Modern Stack - Production'
     },


### PR DESCRIPTION
This resolves issue #260. removed db reference from all.js and added mongohq process environment to productions.js.

The db reference in production.js should point to the heroku environment. Having a DB reference in all.js seems redundant since we have one in each of the three environments (development, production, and testing).
