### PR TITLE
Port configuration for passport in production environment.

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -8,26 +8,26 @@ module.exports = {
     facebook: {
         clientID: 'APP_ID',
         clientSecret: 'APP_SECRET',
-        callbackURL: 'http://localhost:3000/auth/facebook/callback'
+        callbackURL: 'http://localhost:'+ process.env.PORT || '' +'/auth/facebook/callback'
     },
     twitter: {
         clientID: 'CONSUMER_KEY',
         clientSecret: 'CONSUMER_SECRET',
-        callbackURL: 'http://localhost:3000/auth/twitter/callback'
+        callbackURL: 'http://localhost:'+ process.env.PORT || '' +'/auth/twitter/callback'
     },
     github: {
         clientID: 'APP_ID',
         clientSecret: 'APP_SECRET',
-        callbackURL: 'http://localhost:3000/auth/github/callback'
+        callbackURL: 'http://localhost:'+ process.env.PORT || '' +'/auth/github/callback'
     },
     google: {
         clientID: 'APP_ID',
         clientSecret: 'APP_SECRET',
-        callbackURL: 'http://localhost:3000/auth/google/callback'
+        callbackURL: 'http://localhost:'+ process.env.PORT || '' +'/auth/google/callback'
     },
     linkedin: {
         clientID: 'API_KEY',
         clientSecret: 'SECRET_KEY',
-        callbackURL: 'http://localhost:3000/auth/linkedin/callback'
+        callbackURL: 'http://localhost:'+ process.env.PORT || '' +'/auth/linkedin/callback'
     }
 };


### PR DESCRIPTION
Replaced the callbackUrl value for all passport providers in  **config/env/production.js** to insert the value of **process.env.PORT** to the string.
