### PR TITLE
Update Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,13 +107,13 @@ If you are using node instead of grunt, it is very similar:
 
 ## Getting Started
   We pre-included an article example, check it out:
-  * [The Model](https://github.com/linnovate/mean/blob/master/app/models/article.js) - Where we define our object schema.
-  * [The Controller](https://github.com/linnovate/mean/blob/master/app/controllers/articles.js) - Where we take care of our backend logic.
-  * [NodeJS Routes](https://github.com/linnovate/mean/blob/master/config/routes.js) - Where we define our REST service routes.
-  * [AngularJs Routes](https://github.com/linnovate/mean/blob/master/public/js/config.js) - Where we define our CRUD routes.
-  * [The AngularJs Service](https://github.com/linnovate/mean/blob/master/public/js/services/articles.js) - Where we connect to our REST service.
-  * [The AngularJs Controller](https://github.com/linnovate/mean/blob/master/public/js/controllers/articles.js) - Where we take care of  our frontend logic.
-  * [The AngularJs Views Folder](https://github.com/linnovate/mean/blob/master/public/views/articles) - Where we keep our CRUD views.
+  * [The Model](app/models/article.js) - Where we define our object schema.
+  * [The Controller](app/controllers/articles.js) - Where we take care of our backend logic.
+  * [NodeJS Routes](app/routes/articles.js) - Where we define our REST service routes.
+  * [AngularJs Routes](public/js/config.js) - Where we define our CRUD routes.
+  * [The AngularJs Service](public/js/services/articles.js) - Where we connect to our REST service.
+  * [The AngularJs Controller](public/js/controllers/articles.js) - Where we take care of  our frontend logic.
+  * [The AngularJs Views Folder](public/views/articles) - Where we keep our CRUD views.
 
 ## Heroku Quick Deployment
 Before you start make sure you have <a href="https://toolbelt.heroku.com/">heroku toolbelt</a> installed and an accessible mongo db instance - you can try <a href="http://www.mongohq.com/">mongohq</a> which have an easy setup )


### PR DESCRIPTION
The 'Getting Started' section has links to the 'articles' example. However the links were absolute so when the repo is forked the links still point back to the original linnovate repo path.

In addition, the link for 'NodeJS Routes' had not been updated and did not point to a valid page.

both these issues were corrected in this commit
