### PR TITLE
added use of cdn for all of the external components

### DIFF
--- a/app/views/includes/foot.html
+++ b/app/views/includes/foot.html
@@ -1,12 +1,12 @@
 <!-- Angular JS -->
-<script type="text/javascript" src="/lib/angular/angular.min.js"></script>
-<script type="text/javascript" src="/lib/angular-cookies/angular-cookies.min.js"></script>
-<script type="text/javascript" src="/lib/angular-resource/angular-resource.min.js"></script>
-<script type="text/javascript" src="/lib/angular-ui-router/release/angular-ui-router.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.13/angular.min.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.13/angular-cookies.min.js"></script>
+<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.13/angular-resource.min.js"></script>
 
 <!-- Angular UI -->
-<script type="text/javascript" src="/lib/angular-bootstrap/ui-bootstrap.js"></script>
-<script type="text/javascript" src="/lib/angular-bootstrap/ui-bootstrap-tpls.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-router/0.2.0/angular-ui-router.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.10.0/ui-bootstrap.min.js"></script>
+<script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/angular-ui-bootstrap/0.10.0/ui-bootstrap-tpls.min.js"></script>
 
 <!-- Application Init -->
 <script type="text/javascript" src="/js/app.js"></script>

--- a/app/views/includes/head.html
+++ b/app/views/includes/head.html
@@ -19,8 +19,8 @@
     <meta property="og:site_name" content="MEAN - A Modern Stack">
     <meta property="fb:admins" content="APP_ADMIN">
 
-    <link rel="stylesheet" href="/lib/bootstrap/dist/css/bootstrap.min.css">
-    <!-- <link rel="stylesheet" href="/lib/bootstrap/dist/css/bootstrap-responsive.css"> -->
+    <link href="//netdna.bootstrapcdn.com/bootstrap/3.1.1/css/bootstrap.min.css" rel="stylesheet">
+
     <link rel="stylesheet" href="/css/common.css">
 
     <link rel="stylesheet" href="/css/views/articles.css">

--- a/bower.json
+++ b/bower.json
@@ -1,14 +1,5 @@
 {
     "name": "mean",
     "version": "0.1.3",
-    "dependencies": {
-        "angular": "latest",
-        "angular-resource": "latest",
-        "angular-cookies": "latest",
-        "angular-mocks": "latest",
-        "angular-route": "latest",
-        "bootstrap": "3.0.3",
-        "angular-bootstrap": "0.10.0",
-        "angular-ui-router": "#master"
-    }
+    "dependencies": {}
 }


### PR DESCRIPTION
there's no need to hold all these extra files as a local library, in development you can even replace the cdn min.js/min.css urls with the relevant min version so you can debug.

now that the bower.json file has no dependencies, npm install is faster
