### PR TITLE
bug fixed:  location should be in callback of remove

### DIFF
--- a/public/js/controllers/articles.js
+++ b/public/js/controllers/articles.js
@@ -27,8 +27,9 @@ angular.module('mean.articles').controller('ArticlesController', ['$scope', '$st
             }
         }
         else {
-            $scope.article.$remove();
-            $location.path('articles');
+            $scope.article.$remove(function(response){
+                $location.path('articles');
+            });
         }
     };
 


### PR DESCRIPTION
$location should be in callback of $remove, so that the refreshed page would be using the new (with something deleted) data.
