### PR TITLE
fixed the problem with uglify

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -36,6 +36,9 @@ module.exports = function(grunt) {
             }
         },
         uglify: {
+            options: {
+                mangle: false
+            },
             production: {
                 files: '<%= assets.js %>'
             }


### PR DESCRIPTION
It seems like the app with dist.min.js generated by uglify is not
working (i.e. `NODE_ENV=production grunt`). Turning off the “mangle”
option seems to fix the problem.
