### PR TITLE
Fixed active state

### DIFF
--- a/public/system/views/header.html
+++ b/public/system/views/header.html
@@ -3,8 +3,8 @@
         <li>
             <a class="navbar-brand" href="/">MEAN - A Modern Stack</a>
         </li>
-        <li data-ng-repeat="item in menus.main" ui-route="/{{item.link}}" ng-class="{active: $uiRoute}">
-            <a data-ng-if="global.hasRole(item.roles)" ui-sref='{{item.link}}'>{{item.title}}</a>
+        <li data-ng-repeat="item in menus.main" ui-route="/{{item.link}}" ui-sref-active="active" class="">
+            <a data-ng-if="global.user" ui-sref='{{item.link}}'>{{item.title}}</a>
         </li>                
     </ul>
 


### PR DESCRIPTION
1. Active state not showing with `ng-class="{active: $uiRoute}"`. Fix provided using directive `ui-sref-active`.
2. Small fix for displaying _Articles_ menu item upon logging in. Currently requires page to reload.