### PR TITLE
centralizing global authenticated user data

### DIFF
--- a/public/auth/controllers/auth.js
+++ b/public/auth/controllers/auth.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('mean.controllers.login', [])
-    .controller('LoginCtrl', ['$scope','$rootScope','$http','$location', function($scope, $rootScope, $http, $location) {
+    .controller('LoginCtrl', ['$scope','$http','$location','Global', function($scope, $http, $location, Global) {
         // This object will be filled by the form
         $scope.user = {};
 
@@ -14,8 +14,7 @@ angular.module('mean.controllers.login', [])
                 .success(function(user){
                     // authentication OK
                     $scope.loginError = 0;
-                    $rootScope.user = user;
-                    $rootScope.$emit('loggedin');
+                    Global.setUser(user);
                     $location.url('/');
                 })
                 .error(function() {
@@ -23,7 +22,7 @@ angular.module('mean.controllers.login', [])
                 });
         };
     }])
-    .controller('RegisterCtrl', ['$scope','$rootScope','$http','$location', function($scope, $rootScope, $http, $location) {
+    .controller('RegisterCtrl', ['$scope','$http','$location','Global', function($scope, $http, $location, Global) {
         $scope.user = {};
 
         $scope.register = function(){
@@ -39,10 +38,8 @@ angular.module('mean.controllers.login', [])
                 .success(function(){
                     // authentication OK
                     $scope.registerError = 0;
-                    $rootScope.user = $scope.user.fullname;
-                    $rootScope.$emit('loggedin');
+                    Global.setUser($scope.user.fullname);
                     $location.url('/');
-
                 })
                 .error(function(error){
                     // Error: authentication failed

--- a/public/system/controllers/header.js
+++ b/public/system/controllers/header.js
@@ -1,7 +1,7 @@
 'use strict';
 
-angular.module('mean.system').controller('HeaderController', ['$scope', '$rootScope', 'Global', 'Menus',
-    function($scope, $rootScope, Global, Menus) {
+angular.module('mean.system').controller('HeaderController', ['$scope', 'Menus', 'Global',
+    function($scope, Menus, Global) {
         $scope.global = Global;
         $scope.menus = {};
 
@@ -33,15 +33,8 @@ angular.module('mean.system').controller('HeaderController', ['$scope', '$rootSc
 
         $scope.isCollapsed = false;
 
-        $rootScope.$on('loggedin', function() {
-
+        $scope.$on('userChanged', function() {
             queryMenu('main', defaultMainMenu);
-
-            $scope.global = {
-                authenticated: !! $rootScope.user,
-                user: $rootScope.user
-            };
         });
-
     }
 ]);

--- a/public/system/services/global.js
+++ b/public/system/services/global.js
@@ -1,13 +1,17 @@
 'use strict';
 
 //Global service for global variables
-angular.module('mean.system').factory('Global', [
-    function() {
-        var _this = this;
-        _this._data = {
-            user: window.user,
-            authenticated: !! window.user
+angular.module('mean.system').factory('Global', ['$window','$rootScope',
+    function($window, $rootScope) {
+    	var global = {
+            user: $window.user,
+            authenticated: !! $window.user,
+            setUser: function(user) {
+                this.user = user;
+                this.authenticated = !! user;
+                $rootScope.$broadcast('userChanged');
+            }
         };
-        return _this._data;
+        return global;
     }
 ]);

--- a/test/karma/unit/controllers/auth.spec.js
+++ b/test/karma/unit/controllers/auth.spec.js
@@ -77,7 +77,6 @@
             var RegisterCtrl,
                 Global,
                 scope,
-                $rootScope,
                 $httpBackend,
                 $location;
 

--- a/test/karma/unit/controllers/auth.spec.js
+++ b/test/karma/unit/controllers/auth.spec.js
@@ -15,19 +15,20 @@
             beforeEach(module('mean'));
 
             var LoginCtrl,
+                Global,
                 scope,
-                $rootScope,
                 $httpBackend,
                 $location;
 
-            beforeEach(inject(function($controller, _$rootScope_, _$location_, _$httpBackend_) {
+            beforeEach(inject(function($controller, $rootScope, _$location_, _$httpBackend_, _Global_) {
 
-                scope = _$rootScope_.$new();
-                $rootScope = _$rootScope_;
+                scope = $rootScope.$new();
+
+                Global = _Global_;
 
                 LoginCtrl = $controller('LoginCtrl', {
                     $scope: scope,
-                    $rootScope: _$rootScope_
+                    Global: Global
                 });
 
                 $httpBackend = _$httpBackend_;
@@ -42,20 +43,15 @@
             });
 
             it('should login with a correct user and password', function() {
-
-                spyOn($rootScope, '$emit');
                 // test expected GET request
                 $httpBackend.when('POST','/login').respond(200, 'Fred');
+                expect(Global.user).toBe(undefined);
                 scope.login();
                 $httpBackend.flush();
                 // test scope value
-                expect($rootScope.user).toEqual('Fred');
-
-                expect($rootScope.$emit).toHaveBeenCalledWith('loggedin');
+                expect(Global.user).toEqual('Fred');
                 expect($location.url()).toEqual('/');
             });
-
-
 
             it('should fail to log in ', function() {
                 $httpBackend.expectPOST('/login').respond(400, 'Authentication failed');
@@ -79,19 +75,20 @@
             beforeEach(module('mean'));
 
             var RegisterCtrl,
+                Global,
                 scope,
                 $rootScope,
                 $httpBackend,
                 $location;
 
-            beforeEach(inject(function($controller, _$rootScope_, _$location_, _$httpBackend_) {
+            beforeEach(inject(function($controller, $rootScope, _$location_, _$httpBackend_, _Global_) {
 
-                scope = _$rootScope_.$new();
-                $rootScope = _$rootScope_;
+                scope = $rootScope.$new();
+                Global = _Global_;
 
                 RegisterCtrl = $controller('RegisterCtrl', {
                     $scope: scope,
-                    $rootScope: _$rootScope_
+                    Global: Global
                 });
 
                 $httpBackend = _$httpBackend_;
@@ -107,16 +104,15 @@
 
             it('should register with correct data', function() {
 
-                spyOn($rootScope, '$emit');
                 // test expected GET request
                 scope.user.fullname = 'Fred';
                 $httpBackend.when('POST','/register').respond(200, 'Fred');
+                expect(Global.user).toBe(undefined);
                 scope.register();
                 $httpBackend.flush();
                 // test scope value
-                expect($rootScope.user).toBe('Fred');
+                expect(Global.user).toBe('Fred');
                 expect(scope.registerError).toEqual(0);
-                expect($rootScope.$emit).toHaveBeenCalledWith('loggedin');
                 expect($location.url()).toBe('/');
             });
 


### PR DESCRIPTION
Currently, there are two places that store the data of the authenticated user on the client-side: `Global.user` (in the `Global` service) and `$rootScope.user`. One problem is that it's not DRY and is harder to maintain. Another problem is that the index controller uses `Global.user` instead of `$rootScope.user`, but `Global.user` does not get updated when you log in. Instead of having two places to maintain, I'd like to make the `Global` service be the only place that holds the global data shared by all controllers. Instead of setting `$rootScope.user` and firing `$rootScope.emit`, a controller would only have to call `Global.setUser` and let `Global` service do the rest (i.e. broadcasting the change to all controllers).