### PR TITLE
username and provider are unique (username is no longer unique)

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -16,10 +16,7 @@ var UserSchema = new Schema({
         required: true
     },
     email: String,
-    username: {
-        type: String,
-        unique: true
-    },
+    username: String,
     roles: [{
         type: String,
         default: 'authenticated'
@@ -33,6 +30,7 @@ var UserSchema = new Schema({
     google: {},
     linkedin: {}
 });
+UserSchema.index({ username: 1, provider: 1 }, {unique: true});
 
 /**
  * Virtuals

--- a/test/mocha/user/model.js
+++ b/test/mocha/user/model.js
@@ -8,7 +8,7 @@ var should = require('should'),
     User = mongoose.model('User');
 
 //Globals
-var user, user2;
+var user, user2, user3;
 
 //The tests
 describe('<Unit Test>', function() {
@@ -22,7 +22,13 @@ describe('<Unit Test>', function() {
                 provider: 'local'
             });
             user2 = new User(user);
-
+            user3 = new User({
+                name: 'Full name',
+                email: 'test@test.com',
+                username: 'user',
+                password: 'password',
+                provider: 'local'
+            });
             done();
         });
 
@@ -44,6 +50,18 @@ describe('<Unit Test>', function() {
                     should.exist(err);
                     done();
                 });
+            });
+
+            it('should fail to save when username and provider are both duplicates', function(done) {
+                return user3.save(function(err) {
+                    should.exist(err);
+                    done();
+                });
+            });
+
+            it('should save when username is a duplicate', function(done) {
+                user3.provider = 'notlocal'
+                user3.save(done);
             });
 
             it('should show an error when try to save without name', function(done) {


### PR DESCRIPTION
Some context for this change:

I went ahead and set up all the different providers as stubbed out in /server/config/env/development.js . Some providers (Google and LinkedIn) use my email address as my username. This caused an error because the User schema wanted the username to be unique. This restriction makes sense within the context of a provider, so I set the User schema to use a compound index on username and provider which is unique.

I hope this helps.

Cheers,
Mike