### PR TITLE
Added the grunt-contrib-copy package and associated copy task. This task...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,6 +61,11 @@ module.exports = function(grunt) {
                 files: '<%= assets.css %>'
             }
         },
+        copy: {
+            main: {
+                files: '<%= assets.fonts %>'
+            }
+        },
         nodemon: {
             dev: {
                 script: 'server.js',
@@ -120,6 +125,6 @@ module.exports = function(grunt) {
     
     // For Heroku users only.
     // Docs: https://github.com/linnovate/mean/wiki/Deploying-on-Heroku
-    grunt.registerTask('heroku:production', ['jshint', 'csslint', 'cssmin', 'uglify']);
+    grunt.registerTask('heroku:production', ['jshint', 'csslint', 'cssmin', 'uglify', 'copy']);
     
 };

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "grunt-contrib-jshint": "latest",
     "grunt-contrib-uglify": "^0.4.0",
     "grunt-contrib-watch": "latest",
+    "grunt-contrib-copy" : "latest",
     "grunt-env": "^0.4.1",
     "grunt-nodemon": "0.2.0",
     "load-grunt-tasks": "^0.4.0"

--- a/server/config/assets.json
+++ b/server/config/assets.json
@@ -18,5 +18,15 @@
 			"public/*/*/*.js",
 			"!public/build/**"
 		]
-	}
+	},
+	"fonts": [
+		{
+	        "expand": "true",
+	        "flattern": "true",
+	        "filter": "isFile",
+	        "cwd": "public/system/lib/bootstrap/dist/fonts/",
+	        "src": "**",
+	        "dest": "public/build/fonts/"
+       	}
+	]
 }


### PR DESCRIPTION
... will move the glyphicon fonts, from the default bootstrap dist directory, into the public/build/ directory. The bootstrap.min.css file expects the fonts to be in this directory and will cause 404 errors on heroku if they are not present. The copy task has been added the list of tasks run on a heroku production build. If bootstrap is ever served using a CDN, this change should be removed.

Closes #410