### PR TITLE
remove filter for gzipping

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -27,9 +27,6 @@ module.exports = function(app, passport, db) {
     // Should be placed before express.static
     // To ensure that all assets and data are compressed (utilize bandwidth)
     app.use(express.compress({
-        filter: function(req, res) {
-            return (/^text\//).test(res.getHeader('Content-Type'));
-        },
         // Levels are specified in a range of 0 to 9, where-as 0 is
         // no compression and 9 is best compression, but slowest
         level: 9


### PR DESCRIPTION
Reason, compressible already has rules on what to compress, which is what connect uses to determine whether to compress the response:

https://github.com/expressjs/compressible/blob/master/index.js#L7
