### PR TITLE
Removed linting steps for production environment.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -105,9 +105,6 @@ module.exports = function(grunt) {
     //Load NPM tasks
     require('load-grunt-tasks')(grunt);
 
-    //Making grunt default to force in order not to break the project.
-    grunt.option('force', true);
-
     //Default task(s).
     if (process.env.NODE_ENV === 'production') {
         grunt.registerTask('default', ['cssmin', 'uglify', 'concurrent']);


### PR DESCRIPTION
Preventing linting in production seems like the more sane default.  This will help keep the build output cleaner on deployments to heroku as well. 

Also removed grunt.option('force', true) -- this would typically prevent the build process from failing if linting fails.  However, since we would no longer be linting in production by default, this may not be necessary. 

We could also explore adding the force option for non-prod environments as a middleground.
