### PR TITLE
adding grunt support for packages folder. Therefore when user creates new packages, they will automatically have the following support: 1) js jshint & livereload. 2) html livereload. 3) css csslint & livereload.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var paths = {
-    js: ['*.js', 'server/**/*.js', 'public/**/*.js', 'test/**/*.js', '!test/coverage/**', '!public/system/lib/**'],
-    html: ['public/**/views/**', 'server/views/**'],
-    css: ['public/**/css/*.css', '!public/system/lib/**']
+    js: ['*.js', 'server/**/*.js', 'public/**/*.js', 'test/**/*.js', '!test/coverage/**', '!public/system/lib/**', 'packages/**/*.js', 'packages/**/public/**/*.js', 'packages/**/server/**/*.js'],
+    html: ['public/**/views/**', 'server/views/**', 'packages/**/public/**/views/**', 'packages/**/server/views/**'],
+    css: ['public/**/css/*.css', '!public/system/lib/**', 'packages/**/public/**/css/*.css']
 };
 
 module.exports = function(grunt) {


### PR DESCRIPTION
adding grunt support for packages folder. Therefore when user creates new packages, they will automatically have the following support: 
1) js jshint & livereload. 
2) html livereload. 
3) css csslint & livereload.
