### PR TITLE
Fix for UserSchema definition roles attribute - String -> Array

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -20,10 +20,10 @@ var UserSchema = new Schema({
         type: String,
         unique: true
     },
-    roles: [{
-        type: String,
-        default: 'authenticated'
-    }],
+    roles: {
+        type: Array,
+        default: ['authenticated']
+    },
     hashed_password: String,
     provider: String,
     salt: String,


### PR DESCRIPTION
When trying out login through passport (third services) the default value for roles is not valid so even if the user is authenticated it can't see the menus or the logout link.  To fix this it's needed to add a role from the cmd line:

`node ./node_modules/meanio/bin/mean user example@gmail.com -a admin`
