### PR TITLE
Added csurf package since express 4.0 doesn't have csrf by default anymore

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "connect-flash": "^0.1.1",
     "consolidate": "^0.10.0",
     "cookie-parser": "~1.0.1",
+    "csurf": "^1.1.0",
     "dependable": "0.2.5",
     "errorhandler": "~1.0.0",
     "express": "^4.1.0",


### PR DESCRIPTION
I added the [csurf](https://github.com/expressjs/csurf) package to the package.json file, so mean.io can now have support for CSRF out of the box. 

If the user wished to utilize CSRF it would be the exact same as in Express 3.0; however, they must add the following line:

``` javascript
var csrf = require('csurf');
```
