### PR TITLE
When logged in with github, user.roles is empty

### DIFF
--- a/public/system/services/global.js
+++ b/public/system/services/global.js
@@ -7,7 +7,7 @@ angular.module('mean.system').factory('Global', [
         var _this = this;
         _this._data = {
             user: window.user,
-            authenticated: window.user && window.user.roles,
+            authenticated: Boolean(window.user && window.user.roles),
             isAdmin: (window.user && window.user.roles) && window.user.roles.indexOf('admin') > -1
         };
         return _this._data;


### PR DESCRIPTION
`ng-show` and `ng-hide` evaluates `[]` as `false` which is not the desired outcome. forcing user.authenticated to be `boolean` resolves the issue.
