### PR TITLE
updated nodemon config to auto-reload aggregated.js/css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,8 +71,8 @@ module.exports = function(grunt) {
                 script: 'server.js',
                 options: {
                     args: [],
-                    ignore: ['public/**', 'node_modules/**'],
-                    ext: 'js,html',
+                    ignore: ['*.html', 'public/system/**', 'public/auth/**', 'test/coverage/**', 'node_modules/**'],
+                    ext: 'js,html,css',
                     nodeArgs: ['--debug'],
                     delayTime: 1,
                     env: {


### PR DESCRIPTION
See related discussion here:
https://github.com/linnovate/mean/issues/529
- the purpose of this change to enable changes made to package css/js
files to be reflected in the browser after live reload
- since those files are packaged in the aggregated.js/css it requires a
server restart
- without this change, only the grunt ‘watch’ task is activated on a
change to /packages/*.js or *.css