### PR TITLE
adding support for configurable session cookie parameters for express

### DIFF
--- a/server/config/env/all.js
+++ b/server/config/env/all.js
@@ -13,6 +13,24 @@ module.exports = {
     // The secret should be set to a non-guessable string that
     // is used to compute a session hash
     sessionSecret: 'MEAN',
+
     // The name of the MongoDB collection to store sessions in
-    sessionCollection: 'sessions'
+    sessionCollection: 'sessions', 
+
+    // The session cookie settings
+    sessionCookie: { 
+    	path: '/',
+    	httpOnly: true,
+    	// If secure is set to true then it will cause the cookie to be set
+    	// only when SSL-enabled (HTTPS) is used, and otherwise it won't
+    	// set a cookie. 'true' is recommended yet it requires the above
+    	// mentioned pre-requisite.
+    	secure: false,
+    	// Only set the maxAge to null if the cookie shouldn't be expired
+    	// at all. The cookie will expunge when the browser is closed.
+    	maxAge: null
+    },
+
+    // The session cookie name
+    sessionName: 'connect.sid'
 };

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -89,7 +89,9 @@ module.exports = function(app, passport, db) {
         store: new mongoStore({
             db: db.connection.db,
             collection: config.sessionCollection
-        })
+        }),
+        cookie: config.sessionCookie,
+        name: config.sessionName
     }));
 
     // Dynamic helpers


### PR DESCRIPTION
It is often required for enterprise applications to set the session cookie parameters and not rely on express's defaults. These parameters are for example the cookie expiration time, and whether the session cookie will require the website to run in an SSL-enabled environment.

This PR adds support for default parameters on the cookie session and allows developers to set them as required globally, or per environment (dev, test, prod). Description on the session cookie parameters themselves have been added as well to make this easy to configure.
