### PR TITLE
Proper Section HTML / Angular more than once.

### DIFF
--- a/server/views/index.html
+++ b/server/views/index.html
@@ -1,6 +1,6 @@
 {% extends 'layouts/default.html' %}
 {% block content %}
-    <section data-ui-view />
+    <section data-ui-view ></section>
     <script type="text/javascript">
         window.user = {{user|json|safe}};        
         window.modules = {{modules|json|safe}};      


### PR DESCRIPTION
When I moved my Jquery to in front of angularJS from #584 I was receiving the following warning:

```
WARNING: Tried to load angular more than once. VM6729:210
Uncaught Error: [ng:btstrpd] http://errors.angularjs.org/1.2.17/ng/btstrpd?p0=document angular.js:36
WARNING: Tried to load angular more than once. 
```

I had seen this issue before when loading other controls a few weeks back that required JQuery to be initiated before angular. I tracked it down to this incorrect html after reading this: http://stackoverflow.com/questions/23499853/warning-tried-to-load-angular-more-than-once-angular-js
