### PR TITLE
#587 moved setting the env var for port from the gruntfile to server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,9 +16,6 @@ var mongoose = require('mongoose'),
 var config = require('./server/config/config');
 var db = mongoose.connect(config.db);
 
-// Set PORT env variable
-process.env.PORT = process.env.PORT || config.port;
-
 // Bootstrap Models, Dependencies, Routes and the app as an express app
 var app = require('./server/config/system/bootstrap')(passport, db);
 


### PR DESCRIPTION
Moved setting the environment variable for port from the gruntfile to server.js

Using require(...).port to set the env in the gruntfile caused the config to be executed when the gruntfile was initialized.  This caused the grunt test task to be executed in the incorrect environment.
