### PR TITLE
Fix auth index layout problems caused by Bootstrap misusage

### DIFF
--- a/public/auth/views/index.html
+++ b/public/auth/views/index.html
@@ -1,10 +1,10 @@
-<div>
-
+<div class="container">
     <div class="row">
         <div class="col-md-offset-1 col-md-5">
             <a href="/auth/facebook">
                 <img src="/public/auth/assets/img/icons/facebook.png"/>
             </a>
+
             <a href="/auth/github">
                 <img src="/public/auth/assets/img/icons/github.png"/>
             </a>
@@ -15,15 +15,17 @@
 
             <a href="/auth/twitter">
                 <img src="/public/auth/assets/img/icons/twitter.png"/>
-            </a><a href="/auth/google">
-            <img src="/public/auth/assets/img/icons/google.png"/>
-        </a>
+            </a>
+
+            <a href="/auth/google">
+                <img src="/public/auth/assets/img/icons/google.png"/>
+            </a>
         </div>
     </div>
-    <div class="col-md-6">
 
-
-        <div ui-view></div>
+    <div class="row">
+        <div class="col-md-6">
+            <div ui-view></div>
+        </div>
     </div>
-
 </div>


### PR DESCRIPTION
There were some blatant problems with how bootstrap was being used in `public/auth/index.html`, causing layout issues.  This fixes it, along with cleaning up some janky indentation.
