### PR TITLE
incorrect logic for isAdmin

### DIFF
--- a/public/system/services/global.js
+++ b/public/system/services/global.js
@@ -12,7 +12,7 @@ angular.module('mean.system').factory('Global', [
         };
         if (window.user && window.user.roles) {
             _this._data.authenticated = window.user.roles.length;
-            _this._data.isAdmin = window.user.roles.indexOf('admin') > -1;
+            _this._data.isAdmin = window.user.roles.indexOf('admin') !== -1;
         }
         return _this._data;
     }


### PR DESCRIPTION
I was failing authentication this "~window.user.roles.indexOf('admin');" seems completely incorrect. 
->Negate the index of ('admin') I kept getting -1 for the isAdmin function and it should have been true. Or am I missing something here?
