### PR TITLE
Article route tests & bugfix

### DIFF
--- a/packages/articles/server/routes/articles.js
+++ b/packages/articles/server/routes/articles.js
@@ -4,7 +4,7 @@ var articles = require('../controllers/articles');
 
 // Article authorization helpers
 var hasAuthorization = function(req, res, next) {
-    if (!req.user.isAdmin && req.article.user.id !== req.user.id) {
+    if (!req.user.isAdmin() && req.article.user.id !== req.user.id) {
         return res.send(401, 'User is not authorized');
     }
     next();

--- a/packages/articles/test/mocha/article/route.js
+++ b/packages/articles/test/mocha/article/route.js
@@ -1,0 +1,127 @@
+'use strict';
+
+// there has to be a better way to bootstrap package models for mocha tests
+require('../../../server/models/article');
+
+/**
+ * Module dependencies.
+ */
+var request = require('supertest'),
+    mongoose = require('mongoose'),
+    app = require('../../../../../server.js'),
+    session = require('../../../../../test/mocha/user/session.js'),
+    User = mongoose.model('User'),
+    Article = mongoose.model('Article');
+
+//Globals
+var user;
+var user2;
+var article;
+var article2;
+
+var agent = request.agent(app);
+
+//The tests
+describe('<Unit Test>', function() {
+    describe('Route Article:', function() {
+        beforeEach(function(done) {
+            user = new User({
+                name: 'Full name',
+                email: 'test@test.com',
+                username: 'user',
+                password: 'password'
+            });
+
+            user2 = new User({
+                name: 'Full name2',
+                email: 'test2@test.com',
+                username: 'user2',
+                password: 'password'
+            });
+
+            article = new Article({
+                title: 'Article Title',
+                content: 'Article Content',
+                user: user
+            });
+
+            article2 = new Article({
+                title: 'Article Title',
+                content: 'Article Content',
+                user:user2
+
+            });
+
+            user.save(function() {
+
+              session.login(request(app), user, function (loginAgent) {
+                agent = loginAgent;
+                article.save(function(err,saved) {
+                  if(err) throw(err);
+                  article = saved;
+                  user2.save(function() {
+                    article2.save(function(err,saved2) {
+                      if(err) throw(err);
+                      article2 = saved2;
+                      done();
+                    });
+                  });
+                });
+              });
+
+
+            });
+
+
+
+        });
+
+        describe('without authentication', function() {
+            it('should get route /articles', function(done) {
+                request(app).get('/articles').expect(200, done);
+            });
+
+            it('should get route /articles/_id', function(done) {
+                request(app).get('/articles/'+article._id).expect(200, done);
+            });
+
+            it('should not be able to put /articles/_id', function(done) {
+                request(app).put('/articles/'+article._id).expect(401,done);
+            });
+        });
+        describe('with authentication', function() {
+          it('should be able to put own /articles/_id', function(done) {
+              var req = request(app).put('/articles/'+article._id);
+              agent.attachCookies(req);
+              req.expect(200, done);
+          });
+          it('should not be able to put other users /articles/_id', function(done) {
+              var req = request(app).put('/articles/'+article2._id);
+              agent.attachCookies(req);
+              req.expect(401, done);
+          });
+
+        });
+        describe('with authentication and admin role', function() {
+
+            it('should be able to put other users /articles/_id', function(done) {
+                user.roles.push('admin');
+                user.save(function(err) {
+                  if(err) throw(err);
+                  var req = request(app).put('/articles/'+article2._id);
+                  agent.attachCookies(req);
+                  req.expect(200, done);
+                });
+
+            });
+        });
+
+        afterEach(function(done) {
+            article.remove();
+            article2.remove();
+            user.remove();
+            user2.remove();
+            done();
+        });
+    });
+});

--- a/test/mocha/user/session.js
+++ b/test/mocha/user/session.js
@@ -1,0 +1,20 @@
+'use strict';
+
+/* Helper for mocha supertest login */
+
+var superagent = require('supertest');
+var agent = superagent.agent();
+
+
+exports.login = function (request, user, done) {
+  request
+    .post('/login')
+    .send({ email:user.email, password:user.password })
+    .end(function (err, res) {
+      if (err) {
+        throw err;
+      }
+      agent.saveCookies(res);
+      done(agent);
+    });
+};


### PR DESCRIPTION
I have added the Mocha route tests with Supertest, to unit test authorization for Article package, for people to use as an example. It took me a while to figure it out when I wanted to test routes in my project, as there were no examples included, so I figured that it would be good to share it.

Also included little helper, and put it under User test directory, as it is not related directly to Article package.

Besides that, during tests, I discovered the bug (tests!) and fixed it. Turns out that !req.user.isAdmin will always be negative, while !req.user.isAdmin() will use actual value that function returns and then will negate it.