### PR TITLE
updating deprecated bodyParser initialization to use explicit parser met...

### DIFF
--- a/server/config/express.js
+++ b/server/config/express.js
@@ -67,7 +67,10 @@ module.exports = function(app, passport, db) {
 
     // Request body parsing middleware should be above methodOverride
     app.use(expressValidator());
-    app.use(bodyParser());
+    app.use(bodyParser.json());
+    app.use(bodyParser.urlencoded({
+	extended: true
+    }));
     app.use(methodOverride());
 
     // Import the assets file


### PR DESCRIPTION
Express 4 bodyParser support has changed and warnings are issued on deprecated bodyParser constructor invocation:

<code>
body-parser deprecated bodyParser: use individual json/urlencoded middlewares server/config/express.js:71:13
body-parser deprecated urlencoded: explicitly specify "extended: true" for extended parsing node_modules/body-parser/index.js:74:29
</code>

The fix uses explicit bodyParser initialization.
