### PR TITLE
Update user.js

### DIFF
--- a/server/models/user.js
+++ b/server/models/user.js
@@ -135,4 +135,7 @@ UserSchema.methods = {
     }
 };
 
+// Mongoose automatically normalizes the collection name to lower case and ads and "s" to the end
+// so "User" becomes "users"
+// see: http://stackoverflow.com/questions/10547118/why-does-mongoose-always-add-an-s-to-the-end-of-my-collection-name
 mongoose.model('User', UserSchema);


### PR DESCRIPTION
Mongoose automatically normalizes the collection name to lower case and ads and "s" to the end so "User" becomes "users"
See: http://stackoverflow.com/questions/10547118/why-does-mongoose-always-add-an-s-to-the-end-of-my-collection-name
