### PR TITLE
Seems like a developer left karma debug log level to LOG_DEBUG, returned to original LOG_INFO level

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -51,8 +51,7 @@ module.exports = function(config) {
 
         // level of logging
         // possible values: config.LOG_DISABLE || config.LOG_ERROR || config.LOG_WARN || config.LOG_INFO || config.LOG_DEBUG
-//        logLevel: config.LOG_INFO,
-        logLevel: config.LOG_DEBUG,
+        logLevel: config.LOG_INFO,
 
         // enable / disable watching file and executing tests whenever any file changes
         autoWatch: true,


### PR DESCRIPTION
Small fix to clear all the clutter when running tests
