### PR TITLE
Reset Password with better error handling and validation

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -30,6 +30,7 @@ module.exports = {
         clientSecret: 'SECRET_KEY',
         callbackURL: 'http://localhost:3000/auth/linkedin/callback'
     },
+    emailFrom : 'SENDER EMAIL ADDRESS', // sender address like ABC <abc@example.com>
     mailer: {
         service: 'SERVICE_PROVIDER',
         auth: {

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -30,6 +30,7 @@ module.exports = {
         clientSecret: 'SECRET_KEY',
         callbackURL: 'http://localhost:3000/auth/linkedin/callback'
     },
+    emailFrom : 'SENDER EMAIL ADDRESS', // sender address like ABC <abc@example.com>
     mailer: {
         service: 'SERVICE_PROVIDER',
         auth: {

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -31,11 +31,12 @@ module.exports = {
         clientSecret: 'SECRET_KEY',
         callbackURL: 'http://localhost:3000/auth/linkedin/callback'
     },
-     mailer: {
-     service: 'SERVICE_PROVIDER',
-     auth: {
-          user: 'EMAIL_ID',
-          pass: 'PASSWORD'
-      }
+    emailFrom : 'SENDER EMAIL ADDRESS', // sender address like ABC <abc@example.com>
+    mailer: {
+        service: 'SERVICE_PROVIDER',
+        auth: {
+            user: 'EMAIL_ID',
+            pass: 'PASSWORD'
+        }
     }
 };

--- a/packages/users/public/controllers/meanUser.js
+++ b/packages/users/public/controllers/meanUser.js
@@ -90,6 +90,7 @@ angular.module('mean.users')
             $scope.resetpassword = function() {
                 $http.post('/reset/' + $stateParams.tokenId, {
                     password: $scope.user.password,
+                    confirmPassword: $scope.user.confirmPassword
                 })
                 .success(function(response) {
                     $rootScope.user = response.user;
@@ -105,8 +106,11 @@ angular.module('mean.users')
                         $location.url('/');
                     }
                 })
-                .error(function(response) {
-                    $scope.resetpassworderror = 'Could not update password as token is invalid or may have expired';
+                .error(function(error) {
+                    if (error.msg === 'Token invalid or expired')
+                        $scope.resetpassworderror = 'Could not update password as token is invalid or may have expired';
+                    else
+                        $scope.validationError = error;
                 });
             };
         }

--- a/packages/users/public/views/reset-password.html
+++ b/packages/users/public/views/reset-password.html
@@ -1,14 +1,21 @@
 <div data-ng-controller="ResetPasswordCtrl" class="reset-password">
-  <div class="alert alert-danger animated fadeIn" ng-show="resetpassworderror">{{resetpassworderror}}</div>
-  <h1>Enter your new password</h1>
-  <form ng-submit="resetpassword()" class="reset form-horizontal">
-    <label for="password" class="reset-password"> Enter your new password</label>
-    <div class="form-group enter-password">
-        <input id="password" type="password" name="password" class="form-control1" ng-model="user.password"/>
+    <div class="alert alert-danger animated fadeIn" ng-show="resetpassworderror">{{resetpassworderror}}</div>
+     <div ng-repeat="error in validationError">
+        <div class="alert alert-danger animated fadeIn">{{error.msg}}</div>
     </div>
-    <div class="form-group save">
-     <button type="submit" class="btn btn-primary">Save</button>
-    </div>
-  </form>
+    <h1>Enter your new password</h1>
+    <form ng-submit="resetpassword()" class="reset form-horizontal">
+        <div class="form-group">
+            <label for="password" class="reset-password col-md-2"> Enter Password</label>
+            <input id="password" type="password" name="password" ng-model="user.password"/>
+        </div>
+        <div class="form-group">
+            <label for="confirmPassword" class="col-md-2">Repeat Password</label>
+            <input id="confirmPassword" type="password" name="confirmPassword" ng-model="user.confirmPassword"/>
+        </div>
+        <div class="form-group save">
+           <button type="submit" class="btn btn-primary">Save</button>
+       </div>
+    </form>
 </div>
 

--- a/packages/users/server/template.js
+++ b/packages/users/server/template.js
@@ -7,7 +7,6 @@ module.exports = {
             'http://' + req.headers.host + '/#!/reset/' + token + '\n\n' +
             'If you did not request this, please ignore this email and your password will remain unchanged.\n';
         mailOptions.subject = 'Resetting the password';
-        mailOptions.from = 'SENDER EMAIL ADDRESS'; // sender address
         return mailOptions;
     }
 };


### PR DESCRIPTION
Have done the following

a) Reset Password with better error handling and validation - Passwords must match, and length must be between 8-20
b) Also password token and expires must be set to undefined when a new password is saved. (Was apparently commented by mistake)
d) Moved emailFrom to the environment settings (much easier to have all configuration in one place)
d) Other minor changes, indentation and all.
