### PR TITLE
disabling JSONP from ExpressJS config and replacing all responses of jsonp() to json()

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -47,9 +47,6 @@ module.exports = function(app, passport, db) {
     // set .html as the default extension
     app.set('view engine', 'html');
 
-    // Enable jsonp
-    app.enable('jsonp callback');
-
     // The cookieParser should be above session
     app.use(cookieParser());
 

--- a/packages/articles/server/controllers/articles.js
+++ b/packages/articles/server/controllers/articles.js
@@ -29,11 +29,11 @@ exports.create = function(req, res) {
 
     article.save(function(err) {
         if (err) {
-            return res.jsonp(500, {
+            return res.json(500, {
                 error: 'Cannot save the article'
             });
         }
-        res.jsonp(article);
+        res.json(article);
 
     });
 };
@@ -48,11 +48,11 @@ exports.update = function(req, res) {
 
     article.save(function(err) {
         if (err) {
-            return res.jsonp(500, {
+            return res.json(500, {
                 error: 'Cannot update the article'
             });
         }
-        res.jsonp(article);
+        res.json(article);
 
     });
 };
@@ -65,11 +65,11 @@ exports.destroy = function(req, res) {
 
     article.remove(function(err) {
         if (err) {
-            return res.jsonp(500, {
+            return res.json(500, {
                 error: 'Cannot delete the article'
             });
         }
-        res.jsonp(article);
+        res.json(article);
 
     });
 };
@@ -78,7 +78,7 @@ exports.destroy = function(req, res) {
  * Show an article
  */
 exports.show = function(req, res) {
-    res.jsonp(req.article);
+    res.json(req.article);
 };
 
 /**
@@ -87,11 +87,11 @@ exports.show = function(req, res) {
 exports.all = function(req, res) {
     Article.find().sort('-created').populate('user', 'name username').exec(function(err, articles) {
         if (err) {
-            return res.jsonp(500, {
+            return res.json(500, {
                 error: 'Cannot list the articles'
             });
         }
-        res.jsonp(articles);
+        res.json(articles);
 
     });
 };

--- a/packages/system/server/routes/menus.js
+++ b/packages/system/server/routes/menus.js
@@ -20,7 +20,7 @@ module.exports = function(System, app, auth, database) {
                 defaultMenu: defaultMenu
             });
 
-            res.jsonp(items);
+            res.json(items);
         });
 
 };

--- a/packages/users/server/controllers/users.js
+++ b/packages/users/server/controllers/users.js
@@ -110,7 +110,7 @@ exports.create = function(req, res, next) {
  * Send User
  */
 exports.me = function(req, res) {
-    res.jsonp(req.user || null);
+    res.json(req.user || null);
 };
 
 /**
@@ -136,10 +136,10 @@ exports.user = function(req, res, next, id) {
 exports.resetpassword = function(req, res, next) {
     User.findOne({ resetPasswordToken: req.params.token, resetPasswordExpires: { $gt: Date.now() } }, function(err, user) {
         if (err) {
-            return res.status(400).jsonp({msg: err});
+            return res.status(400).json({msg: err});
         }
         if (!user) {
-            return res.status(400).jsonp({msg: 'Token invalid or expired'});
+            return res.status(400).json({msg: 'Token invalid or expired'});
         }
         req.assert('password', 'Password must be between 8-20 characters long').len(8, 20);
         req.assert('confirmPassword', 'Passwords do not match').equals(req.body.password);
@@ -209,10 +209,10 @@ exports.forgotpassword = function(req, res, next) {
                 'message' : 'User does not exist',
                 'status' : 'danger'
             };
-            res.jsonp(response);
+            res.json(response);
         }
         else {
-            res.jsonp(response);
+            res.json(response);
         }
     });
 };


### PR DESCRIPTION
This is basically a re-do of PR https://github.com/linnovate/mean/pull/336 for the updated 0.4 version of MEAN. I believe the original request is correct and we shouldn't be enabling JSONP by default unless it is really required as it may open CSRF and other security related issues.
