### PR TITLE
updating expressjs method from 'host' to 'hostname' as the former is deprecated

### DIFF
--- a/packages/system/server/views/includes/foot.html
+++ b/packages/system/server/views/includes/foot.html
@@ -6,5 +6,5 @@
 
 {% if (process.env.NODE_ENV == 'development') %}
     <!-- Livereload script rendered -->
-    <script type="text/javascript" src="{{'http://' + req.host + ':35729/livereload.js'}}"></script>
+    <script type="text/javascript" src="{{'http://' + req.hostname + ':35729/livereload.js'}}"></script>
 {% endif %}


### PR DESCRIPTION
Fixes expressjs deprecated method:

```
Mean app started on port 3000 (development)

express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:105
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:136
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:220
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:251
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:277
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:479
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:510
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:594
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:625
express deprecated req.host: Use req.hostname instead eval at <anonymous> (/home/superman/websites/lirantal.mean/node_modules/swig/lib/swig.js:483:11), <anonymous>:28:651
```
