### PR TITLE
fix email check regex

### DIFF
--- a/packages/users/server/models/user.js
+++ b/packages/users/server/models/user.js
@@ -43,7 +43,7 @@ var UserSchema = new Schema({
     type: String,
     required: true,
     unique: true,
-    match: [/.+\@.+\..+/, 'Please enter a valid email'],
+    match: [/\S+@\S+\.\S+/, 'Please enter a valid email'],
     validate: [validateUniqueEmail, 'E-mail address is already in-use']
   },
   username: {


### PR DESCRIPTION
Due to RFC specification http://en.wikipedia.org/wiki/E-mail_address#RFC_specification , email address cannot contains space
