### PR TITLE
Clean up gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,55 @@
+# --------------------
+# OSX Files
+# --------------------
 .DS_Store
+.AppleDouble
+.LSOverride
+Icon
+._*
+.Spotlight-V100
+.Trashes
+
+# --------------------
+# IntelliJ Files
+# --------------------
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# --------------------
+# Netbeans Files
+# --------------------
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+
+# --------------------
+# Node Files
+# --------------------
 .nodemonignore
 npm-debug.log
-.sass-cache/
-.bower-*/
-.idea/
-nbproject/
 node_modules/
+
+# --------------------
+# SASS Files
+# --------------------
+.sass-cache/
+
+# --------------------
+# Bower Files
+# --------------------
+.bower-*/
 bower_components
-mean.iml
+
+# --------------------
+# App Files
+# --------------------
 test/coverage/
 modules/public/
 modules/views/
 /public/build/
-/nbproject/private/


### PR DESCRIPTION
This PR provides more structure and completeness to the `.gitignore` file. The extra (or generalized) ignored file/folder types are there for completeness and are provided by [Github's gitignore project](https://github.com/github/gitignore).
