### PR TITLE
Added database options example to the production environment config

### DIFF
--- a/config/env/production.js
+++ b/config/env/production.js
@@ -2,6 +2,30 @@
 
 module.exports = {
   db: 'mongodb://localhost/mean-prod',
+  /**
+   * Database options that will be passed directly to mongoose.connect
+   * Below are some examples.
+   * See http://mongodb.github.io/node-mongodb-native/driver-articles/mongoclient.html#mongoclient-connect-options
+   * and http://mongoosejs.com/docs/connections.html for more information
+   */
+  dbOptions: {
+    /*
+    server: {
+        socketOptions: {
+            keepAlive: 1
+        },
+        poolSize: 5
+    },
+    replset: {
+      rs_name: 'myReplicaSet',
+      poolSize: 5
+    },
+    db: {
+      w: 1,
+      numberOfRetries: 2
+    }
+    */
+  },
   app: {
     name: 'MEAN - A Modern Stack - Production'
   },


### PR DESCRIPTION
I added an example to the production.js file for the new feature added in mean-cli with [PR 23](https://github.com/linnovate/mean-cli/pull/23) Let me know if there is anywhere else you'd rather have this.
