### PR TITLE
Added a default database file so passwords don't have to be in the repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ test/coverage/
 modules/public/
 modules/views/
 /public/build/
+config/env/database.js

--- a/config/env/database.js.default
+++ b/config/env/database.js.default
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = {
+	development: 'mongodb://localhost/mean-dev',
+	test: 'mongodb://localhost/mean-test',
+	prod: 'mongodb://localhost/mean-prod'
+};

--- a/config/env/development.js
+++ b/config/env/development.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var database = require('./database');
+
 module.exports = {
-  db: 'mongodb://localhost/mean-dev',
+  db: database.development,
   mongoose: {
     debug: true
   },

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var database = require('./database');
+
 module.exports = {
-  db: 'mongodb://localhost/mean-prod',
+  db: database.production,
   app: {
     name: 'MEAN - A Modern Stack - Production'
   },

--- a/config/env/test.js
+++ b/config/env/test.js
@@ -1,7 +1,9 @@
 'use strict';
 
+var database = require('./database');
+
 module.exports = {
-  db: 'mongodb://localhost/mean-test',
+  db: database.test,
   port: 3001,
   app: {
     name: 'MEAN - A Modern Stack - Test'


### PR DESCRIPTION
Just an idea to put the database information in a separate config file that doesn't have to be stored in the repository so you can put passwords in it. This would require that you copy the `database.js.default` to `database.js` before running the app. If we do want to do this, we could also add a section for the `dbOptions` key to the `database.js` file.
