### PR TITLE
Fix for missing dependency 'ms'.

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "karma-phantomjs-launcher": "^0.1.4",
     "karma-requirejs": "^0.2.1",
     "karma-script-launcher": "^0.1.0",
+    "ms": "^0.6.2",
     "requirejs": "^2.1.11",
     "should": "3.3.1",
     "supertest": "0.11.0"


### PR DESCRIPTION
This should fix the error from a missing dependecy 'ms'.

/var/projects/node_modules/serve-favicon/index.js:16
    `var ms = require('ms');`

---

```
Mean app started on port 3000 (development)
/var/projects/test/node_modules/meanio/node_modules/q/q.js:126
                throw e;
                      ^
Error: Cannot find module 'ms'
at Function.Module._resolveFilename (module.js:331:15)
at Function.Module._load (module.js:273:25)
at Module.require (module.js:357:17)
at require (module.js:373:17)
at Object.<anonymous> (/var/projects/test/node_modules/serve-favicon/index.js:16:10)
at Module._compile (module.js:449:26)
at Object.Module._extensions..js (module.js:467:10)
at Module.load (module.js:349:32)
at Function.Module._load (module.js:305:12)
at Module.require (module.js:357:17)
at require (module.js:373:17)
at Object.<anonymous> (/var/projects/test/packages/system/app.js:7:13)
```
