### PR TITLE
SEO friendly articles

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -45,6 +45,6 @@ module.exports = {
   // The session cookie name
   sessionName: 'connect.sid',
   articles: {
-    SEO: false 
+    SEO: true 
   }
 };

--- a/config/env/all.js
+++ b/config/env/all.js
@@ -43,5 +43,8 @@ module.exports = {
   },
 
   // The session cookie name
-  sessionName: 'connect.sid'
+  sessionName: 'connect.sid',
+  articles: {
+    SEO: false 
+  }
 };

--- a/packages/articles/server/controllers/articles.js
+++ b/packages/articles/server/controllers/articles.js
@@ -24,7 +24,10 @@ exports.article = function(req, res, next, id) {
  */
 
 function saveArticle(res, article, title){
-  var articlesConfig = require('meanio').config.clean.articles;
+  var articlesConfig = require('meanio').config;
+  if (!!articlesConfig){
+    articlesConfig = articlesConfig.clean.articles;
+  }
   if (!!articlesConfig && !!articlesConfig.SEO){
     article._id = title;
   }

--- a/packages/articles/server/controllers/articles.js
+++ b/packages/articles/server/controllers/articles.js
@@ -7,7 +7,6 @@ var mongoose = require('mongoose'),
   Article = mongoose.model('Article'),
   _ = require('lodash');
 
-
 /**
  * Find article by id
  */
@@ -23,12 +22,21 @@ exports.article = function(req, res, next, id) {
 /**
  * Create an article
  */
-exports.create = function(req, res) {
-  var article = new Article(req.body);
-  article.user = req.user;
 
+function saveArticle(res, article, title){
+  var articlesConfig = require('meanio').config.clean.articles;
+  if (!!articlesConfig && !!articlesConfig.SEO){
+    article._id = title;
+  }
   article.save(function(err) {
     if (err) {
+      console.log(err);
+      if (!!articlesConfig && !!articlesConfig.SEO){
+        if(err.code === 11000){
+          saveArticle(res,article,title+'_');
+          return;
+        }
+      }
       return res.json(500, {
         error: 'Cannot save the article'
       });
@@ -36,6 +44,16 @@ exports.create = function(req, res) {
     res.json(article);
 
   });
+}
+
+function sanitize(text){
+  return encodeURIComponent(text);
+}
+
+exports.create = function(req, res) {
+  var article = new Article(req.body);
+  article.user = req.user;
+  saveArticle(res, article, sanitize(article.title));
 };
 
 /**

--- a/packages/articles/server/models/article.js
+++ b/packages/articles/server/models/article.js
@@ -6,11 +6,13 @@
 var mongoose = require('mongoose'),
   Schema = mongoose.Schema;
 
+var articlesConfig = require('meanio').config.clean.articles;
+
 
 /**
  * Article Schema
  */
-var ArticleSchema = new Schema({
+var schemaObj = {
   created: {
     type: Date,
     default: Date.now
@@ -29,7 +31,15 @@ var ArticleSchema = new Schema({
     type: Schema.ObjectId,
     ref: 'User'
   }
-});
+};
+
+if (!!articlesConfig && !!articlesConfig.SEO){
+  schemaObj._id = {
+    type: String
+  };
+}
+
+var ArticleSchema = new Schema(schemaObj);
 
 /**
  * Validations

--- a/packages/articles/server/models/article.js
+++ b/packages/articles/server/models/article.js
@@ -6,7 +6,10 @@
 var mongoose = require('mongoose'),
   Schema = mongoose.Schema;
 
-var articlesConfig = require('meanio').config.clean.articles;
+var articlesConfig = require('meanio').config;
+if (!!articlesConfig){
+  articlesConfig = articlesConfig.clean.articles;
+}
 
 
 /**


### PR DESCRIPTION
The example articles package now gets another example for custom mongodb ids.
Instead of using the standard ObjectId from mongo, this extension creates unique String ids and hands them over to mongodb.
With this approach, mean articles become 'SEO friendly'.
The extension is activated through a config setting in the standard mean way. Currently it is in config/env/all.js, in the form of:

    articles: {
       SEO: false //or true
    }

The algorithm for generating unique String ids from titles is simple:
1. 'sanitize' the title of the article to create/save
2. try to write the article with the generated unique String id
3. on duplicate key failure, append an underscore sign _ to the unique String id, and go back to 2

Sanitize is done through a simple encodeURIComponent call. More specific algorithms might be implemented through specialization of the value for the SEO config parameter.

Disclaimer: the extension is still in 'example mode'. It is imporant to note that on a single database one should not switch from ObjectIds to Strings by switching the SEO parameter from false to true. Whatever option is chosen, articles created using the opposite option will not be fetchable from the database.