### PR TITLE
Label Fix: Login to Log In, Sign out to Sign Out, Register to Join

### DIFF
--- a/packages/system/public/views/header.html
+++ b/packages/system/public/views/header.html
@@ -17,10 +17,10 @@
       <div class="pull-right" data-ng-show="global.authenticated" mean-translate></div>
     </div>
     <ul class="navbar-nav nav" data-ng-hide="global.authenticated">
-      <li><a ui-sref='auth.register'>Register</a>
+      <li><a ui-sref='auth.register'>Join</a>
       </li>
       <li class="divider-vertical"></li>
-      <li><a ui-sref='auth.login'>Login</a>
+      <li><a ui-sref='auth.login'>Log In</a>
       </li>
     </ul>
     <ul class="navbar-nav nav" data-ng-show="global.authenticated">
@@ -29,7 +29,7 @@
           {{global.user.name}} <b class="caret"></b>
         </a>
         <ul class="dropdown-menu">
-          <li><a href="/logout">Sign out</a>
+          <li><a href="/logout">Log Out</a>
           </li>
         </ul>
       </li>


### PR DESCRIPTION
Information Architects try to use labels that people would say out loud. When I hear people ask me computer questions, they might say "Tyler! I JOINED Facebook!" or "Tyler? How do I sign up for Facebook?" I think what you guys have is great, I'm just polishing it a little bit. Really you could choose either Sign Up or Join, but I thought Join had better connotations. If we can make the user pause to think a split second less before they clicked on the link, mission accomplish. Das good design.
