### PR TITLE
Made the Log In Buttons More Obvious

### DIFF
--- a/packages/theme/public/assets/css/loginForms.css
+++ b/packages/theme/public/assets/css/loginForms.css
@@ -235,6 +235,22 @@ background: url("/theme/assets/img/bg.png");
     outline: none;
 }
 
+a.button {
+    border:1px solid #333!important;
+    font-weight: bold !important;
+    border-radius: 5px;
+    color: #eee;
+   background: #ffffff; /* Old browsers */
+background: -moz-linear-gradient(top, #ffffff 0%, #e5e5e5 100%); /* FF3.6+ */
+background: -webkit-gradient(linear, left top, left bottom, color-stop(0%,#ffffff), color-stop(100%,#e5e5e5)); /* Chrome,Safari4+ */
+background: -webkit-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* Chrome10+,Safari5.1+ */
+background: -o-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* Opera 11.10+ */
+background: -ms-linear-gradient(top, #ffffff 0%,#e5e5e5 100%); /* IE10+ */
+background: linear-gradient(to bottom, #ffffff 0%,#e5e5e5 100%); /* W3C */
+filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#ffffff', endColorstr='#e5e5e5',GradientType=0 ); /* IE6-9 */
+
+}
+
 .button_login p,
 .button_send p,
 .button_register p {


### PR DESCRIPTION
Hey guys! I was feeling pretty encouraged from my last update so I spent a little time tonight playing with the login again. Some of you might have opinions against this, and that's fine. There's this debate out right now about "flat" design and how people don't know whether icons are buttons. It's much easier (more usable) for the user if it's obvious that something's a button. As it was, the 'Log In With Facebook' buttons were exactly the same style as the text input boxes. I made it more obvious that they're buttons by shading them.

I think the shading sets up a nice contrast, making the page more attractive. But if you guys want to be consistent with your Submit button or someone's a huge fan of the flat design fad, feel free to make adjustments :) Okay! Thanks everyone!
