### PR TITLE
Update passport.js to handle errors

### DIFF
--- a/packages/access/server/config/passport.js
+++ b/packages/access/server/config/passport.js
@@ -110,8 +110,12 @@ module.exports = function(passport) {
           roles: ['authenticated']
         });
         user.save(function(err) {
-          if (err) console.log(err);
-          return done(err, user);
+          if (err) {
+            console.log(err);
+            return done(null, false, {message: 'Facebook login failed, email already in use'});
+          } else {
+            return done(err, user);
+          }
         });
       });
     }


### PR DESCRIPTION
Updated Facebook strategy to handle error when user tries to authenticate with Facebook after he has used his email to authenticate using other strategies. This should also be done for Google strategy etc.
