### PR TITLE
fixed #781 issue in registration where 'email is taken' error is showing up wrongly

### DIFF
--- a/packages/users/server/controllers/users.js
+++ b/packages/users/server/controllers/users.js
@@ -69,11 +69,6 @@ exports.create = function(req, res, next) {
     if (err) {
       switch (err.code) {
         case 11000:
-          res.status(400).send([{
-            msg: 'Email already taken',
-            param: 'email'
-          }]);
-          break;
         case 11001:
           res.status(400).send([{
             msg: 'Username already taken',


### PR DESCRIPTION
fixed issue https://github.com/linnovate/mean/issues/781

'email is taken' error is showing up wrongly instead of username is taken due to emails having their own validations and username check fails on mongoose uniqueness mongodb error constraint
