### PR TITLE
Update meanUser.js

### DIFF
--- a/packages/users/public/controllers/meanUser.js
+++ b/packages/users/public/controllers/meanUser.js
@@ -14,7 +14,7 @@ angular.module('mean.users')
         .success(function(config) {
           for (var conf in config) {
             // Do not show auth providers that have the value DEFAULT as their clientID
-            if (config[conf].hasOwnProperty(clientIdProperty) && config[conf][clientIdProperty].indexOf(defaultPrefix) !== -1) {
+            if (config[conf].hasOwnProperty(clientIdProperty) && config[conf][clientIdProperty].indexOf(defaultPrefix) === -1) {
               $scope.socialButtons[conf] = true;
               $scope.socialButtonsCounter += 1;
             }


### PR DESCRIPTION
Fix logic to show/hide auth providers display. The current conditional on line 17 "... indexOf(defaultPrefix) !== -1)" shows the buttons when using "DEFAULT_" and hides the buttons when properly configured
