### PR TITLE
Remove get-config route

### DIFF
--- a/packages/users/public/controllers/meanUser.js
+++ b/packages/users/public/controllers/meanUser.js
@@ -10,14 +10,11 @@ angular.module('mean.users')
       $scope.socialButtons = {};
       $scope.socialButtonsCounter = 0;
       $scope.global = Global;
-      $http.get('/get-config')
+      $http.post('/get-auth-providers')
         .success(function(config) {
-          for (var conf in config) {
-            // Do not show auth providers that have the value DEFAULT as their clientID
-            if (config[conf].hasOwnProperty(clientIdProperty) && config[conf][clientIdProperty].indexOf(defaultPrefix) !== -1) {
-              $scope.socialButtons[conf] = true;
-              $scope.socialButtonsCounter += 1;
-            }
+          for (var conf in config) {         
+            $scope.socialButtons[conf] = true;
+            $scope.socialButtonsCounter += 1;
           }
         });
     }

--- a/packages/users/server/routes/users.js
+++ b/packages/users/server/routes/users.js
@@ -40,11 +40,21 @@ module.exports = function(MeanUser, app, auth, database, passport) {
         redirect: (req.user.roles.indexOf('admin') !== -1) ? req.get('referer') : false
       });
     });
-
-  // AngularJS route to get config of social buttons
-  app.route('/get-config')
-    .get(function (req, res) {
-      res.send(config);
+  // AngularJS route to return social callbackURL
+  app.route('/get-auth-providers')
+    .post(function (req, res) {
+      var clientIdProperty = 'clientID',
+      defaultPrefix = 'DEFAULT_',
+      callbackURL = 'callbackURL',
+      response={};
+      for(var conf in config){
+        if (config[conf] !== undefined && config[conf][clientIdProperty] !== undefined){
+          if(config[conf][clientIdProperty].toString().indexOf(defaultPrefix) === -1) {
+              response[conf] = config[conf][callbackURL];
+          }
+        }
+      }
+      res.send(response);
     });
 
   // Setting the facebook oauth routes


### PR DESCRIPTION
I have removed the get-config route and add a get-auth-provider route to allow angular get an object with the auth-providers configured in the server without showing all the configuration in the client side.