### PR TITLE
Changed grunt jshint options to allow grunt with no force

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,12 +41,12 @@ module.exports = function(grunt) {
       }
     },
     jshint: {
-      all: {
-        src: paths.js,
-        options: {
-          jshintrc: true
-        }
-      }
+      options: {
+        node: true
+      },
+      all: [
+        'Gruntfile.js'
+      ]
     },
     uglify: {
       core: {


### PR DESCRIPTION
I no longer need to use `grunt -f` to run the server and start the mean app.
