### PR TITLE
Easing debugging Jasmine Karma Tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,6 +106,11 @@ module.exports = function(grunt) {
     karma: {
       unit: {
         configFile: 'karma.conf.js'
+      },
+      server: {
+        configFile: 'karma.conf.js',
+        singleRun: false,
+        browsers: []
       }
     }
   });

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -25,7 +25,7 @@ module.exports = function(config) {
 
     // test results reporter to use
     // possible values: 'dots', 'progress', 'junit', 'growl', 'coverage'
-    reporters: ['progress', 'coverage'],
+    reporters: ['progress', 'coverage', 'html'],
 
     // coverage
     preprocessors: {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "karma-firefox-launcher": "^0.1.3",
     "karma-html2js-preprocessor": "^0.1.0",
     "karma-jasmine": "^0.1.5",
+    "karma-jasmine-html-reporter": "^0.1.5",
     "karma-ng-html2js-preprocessor": "^0.1.0",
     "karma-ng-scenario": "^0.1.0",
     "karma-phantomjs-launcher": "^0.1.4",


### PR DESCRIPTION
This pull request adds a new karma:server task to grunt that will spawn up a karma server and keep it open so you can point your browser to it. In addition to that, this adds a karma jasmine html reporter that will populate the karma debug page with the jasmine spec runner so it's not blank and is more usable for debugging failed tests.