### PR TITLE
consistently set all user models upon login

### DIFF
--- a/packages/users/public/controllers/meanUser.js
+++ b/packages/users/public/controllers/meanUser.js
@@ -53,6 +53,9 @@ angular.module('mean.users')
             // authentication OK
             $scope.loginError = 0;
             $rootScope.user = response.user;
+            Global.user = response.user;
+            window.user = response.user;
+            Global.authenticated = !! $rootScope.user;
             $rootScope.$emit('loggedin');
             if (response.redirect) {
               if (window.location.href === response.redirect) {
@@ -113,6 +116,7 @@ angular.module('mean.users')
             $scope.registerError = 0;
             $rootScope.user = $scope.user;
             Global.user = $rootScope.user;
+            window.user = $rootScope.user;
             Global.authenticated = !! $rootScope.user;
             $rootScope.$emit('loggedin');
             $location.url('/');
@@ -158,6 +162,9 @@ angular.module('mean.users')
         })
           .success(function(response) {
             $rootScope.user = response.user;
+            Global.user = response.user;
+            window.user = response.user;
+            Global.authenticated = !! response.user;
             $rootScope.$emit('loggedin');
             if (response.redirect) {
               if (window.location.href === response.redirect) {


### PR DESCRIPTION
The various controllers in the user package updated some combination of the following properties for each login event:

$rootScope.user
Global.user
Global.authenticated

But they weren't all updated in all circumstances.

Additionally, window.user gets set in the default index.html, but never gets updated on login events.

This pull request consistently updates all user values upon each of the login events.