### PR TITLE
add callbacks for mongoose remove method

### DIFF
--- a/packages/articles/server/tests/articles.js
+++ b/packages/articles/server/tests/articles.js
@@ -82,9 +82,9 @@ describe('<Unit Test>', function() {
     });
 
     afterEach(function(done) {
-      article.remove();
-      user.remove();
-      done();
+      article.remove(function () {
+        user.remove(done);
+      });
     });
   });
 });


### PR DESCRIPTION
Article tests were failing.

```
<Unit Test> Model Article: "before each" hook:
Error: timeout of 2000ms exceeded
at null.<anonymous> (/Users/andra/trash/mean/node_modules/grunt-mocha-test/node_modules/mocha/lib/runnable.js:139:19)
at Timer.listOnTimeout [as ontimeout] (timers.js:110:15)
```

After looking closer at the `beforeEach` and  `afterEach` calls in `packages/articles/server/tests/articles.js`, we stumbled across this gem in the [mongoose docs](http://mongoosejs.com/docs/api.html#query_Query-remove):
_"The operation is only executed when a callback is passed. To force execution without a callback (which would be an unsafe write), we must first call remove() and then execute it by using the exec() method."_

It seems like those removes were never actually being executed properly! Supplying callbacks appears to have fixed the test.

Thanks to @andrija-hers for his help finding and diagnosing the bug!
