### PR TITLE
.gitignore for Eclipse or Nodeclipse "Enide Studio"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,16 @@ Icon
 .Trashes
 
 # --------------------
+# Eclipse or Nodeclipse "Enide Studio" Files
+# --------------------
+# recommended to add to Git SCM
+# or generate with `nodeclipse -p` command
+.project
+.settings/
+.*.md.html
+
+
+# --------------------
 # IntelliJ Files
 # --------------------
 *.iml


### PR DESCRIPTION
Eclipse-based Nodeclipse "Enide Studio" has support for MEAN

though we have open issue https://github.com/Nodeclipse/nodeclipse-1/issues/159
