### PR TITLE
change \ in url in window to /

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -19,8 +19,7 @@ var mean = require('meanio'),
   config = mean.loadConfig();
 
 function onAggregatedSrc(loc,ext,res,next,data){
-  var isWin = /^win/.test(process.platform);
-  if(isWin) {
+  if(mean.platform.isWin()) {
     for (var i = 0; i < data.length; i++) {
       data[i]=data[i].replace(/\\/g,'/');
     }

--- a/config/express.js
+++ b/config/express.js
@@ -19,6 +19,13 @@ var mean = require('meanio'),
   config = mean.loadConfig();
 
 function onAggregatedSrc(loc,ext,res,next,data){
+  var isWin = /^win/.test(process.platform);
+  if(isWin) {
+    for (var i = 0; i < data.length; i++) {
+      data[i]=data[i].replace(/\\/g,'/');
+    }
+  }
+
   res.locals.aggregatedassets[loc][ext] = data;
   next && next();
 }


### PR DESCRIPTION
path.join witch is used to create file paths for public files, joins
using \\ in windows witch is a wrong separator for a url