### PR TITLE
Hide sensitive fields from the API

### DIFF
--- a/packages/users/server/models/user.js
+++ b/packages/users/server/models/user.js
@@ -153,6 +153,18 @@ UserSchema.methods = {
     if (!password || !this.salt) return '';
     var salt = new Buffer(this.salt, 'base64');
     return crypto.pbkdf2Sync(password, salt, 10000, 64).toString('base64');
+  },
+
+  /**
+   * Hide security sensitive fields
+   * 
+   * @returns {*|Array|Binary|Object}
+   */
+  toJSON: function() {
+    var obj = this.toObject();
+    delete obj.hashed_password;
+    delete obj.salt;
+    return obj;
   }
 };
 


### PR DESCRIPTION
Exclude the `salt` and the `hashed_password` from the API
