### PR TITLE
ability to add grunt tasks to packages

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,11 +113,17 @@ module.exports = function(grunt) {
   //Load NPM tasks
   require('load-grunt-tasks')(grunt);
 
+  // Load local tasks from 'tasks' directory
+  grunt.loadTasks('tasks');
+
+  // Load package tasks
+  require('glob').sync('packages/**/tasks').forEach(grunt.loadTasks);
+
   //Default task(s).
   if (process.env.NODE_ENV === 'production') {
-    grunt.registerTask('default', ['clean', 'cssmin', 'uglify', 'concurrent']);
+    grunt.registerTask('default', ['clean', 'cssmin', 'uglify', 'package-default', 'concurrent']);
   } else {
-    grunt.registerTask('default', ['clean', 'jshint', 'csslint', 'concurrent']);
+    grunt.registerTask('default', ['clean', 'jshint', 'csslint', 'package-default', 'concurrent']);
   }
 
   //Test task.

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "express-session": "^1.1.0",
     "express-validator": "^2.1.1",
     "forever": "^0.11.1",
+    "glob": "^4.3.1",
     "gridfs-stream": "^0.5.1",
     "grunt-cli": "^0.1.13",
     "grunt-concurrent": "^1.0.0",

--- a/tasks/package-default.js
+++ b/tasks/package-default.js
@@ -1,0 +1,15 @@
+'use strict';
+
+// read default tasks from packages
+module.exports = function(grunt) {
+    grunt.registerTask('package-default', 'Run default package tasks', function() {
+        var options = this.options();
+        if (options && options.tasks) {
+            Object.keys(options.tasks).forEach(function(task) {
+                if (task) {
+                    grunt.task.run(task);
+                }
+            });
+        }
+    });
+};


### PR DESCRIPTION
This PR adds the ability to add grunt tasks to packages, and for packages to be able to default 'default' tasks.  It's a result of the discussion in https://github.com/linnovate/mean/pull/938

To add a task in a package, just create a 'tasks' directory in the package root and create a js file in it.

The task can then opt in to be run by default like so:

```
module.exports = function(grunt) {
  grunt.config('package-default', {
    options: {
      tasks: {
        'my-default-task': true
      }
    }
  });

  grunt.registerTask('my-default-task', '...', function() {
    // do something
  });
};
```

I have a proof of concept including a default package task (sass compiler) at https://github.com/rmisiak/mean/tree/package-grunt-poc
