### PR TITLE
Add field for updated

### DIFF
--- a/packages/articles/server/models/article.js
+++ b/packages/articles/server/models/article.js
@@ -28,6 +28,9 @@ var ArticleSchema = new Schema({
   user: {
     type: Schema.ObjectId,
     ref: 'User'
+  },
+  updated: {
+    type: Array
   }
 });
 


### PR DESCRIPTION
It appears that the ability to save a timestamp for the dates that each article was updated was intended to be added, as evidenced in packages/articles/public/controllers/articles.js:

```Javascript
        if (!article.updated) {
          article.updated = [];
        }
        article.updated.push(new Date().getTime());
```


but was never added to the model in the server side code.

This simply adds "updated" to the model, so that the data can be saved