### PR TITLE
removed unecessary ui-bootstrap.js from assets.json

### DIFF
--- a/config/assets.json
+++ b/config/assets.json
@@ -11,7 +11,6 @@
         "bower_components/angular-cookies/angular-cookies.js",
         "bower_components/angular-resource/angular-resource.js",
         "bower_components/angular-ui-router/release/angular-ui-router.js",
-        "bower_components/angular-bootstrap/ui-bootstrap.js",
         "bower_components/angular-bootstrap/ui-bootstrap-tpls.js"
       ]
     }


### PR DESCRIPTION
Removed the ```ui-bootstrap.js``` from the ```assets.json``` file because all functionality of that file is also contained in ```ui-bootstrap-tpls.js```

This is my first pull-request so hopefully I didn't break any protocol.