### PR TITLE
Fixes 3rd party login with passport

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "passport-facebook": "1.0.3",
     "passport-github": "0.1.5",
     "passport-google-oauth": "0.1.5",
-    "passport-linkedin": "0.1.3",
+    "passport-linkedin-oauth2": "1.2.1",
     "passport-local": "1.0.0",
     "passport-twitter": "1.0.2",
     "serve-favicon": "2.2.0",

--- a/packages/access/server/config/passport.js
+++ b/packages/access/server/config/passport.js
@@ -6,7 +6,7 @@ var mongoose = require('mongoose'),
   FacebookStrategy = require('passport-facebook').Strategy,
   GitHubStrategy = require('passport-github').Strategy,
   GoogleStrategy = require('passport-google-oauth').OAuth2Strategy,
-  LinkedinStrategy = require('passport-linkedin').Strategy,
+  LinkedinStrategy = require('passport-linkedin-oauth2').Strategy,
   User = mongoose.model('User'),
   config = require('meanio').loadConfig();
 
@@ -193,10 +193,11 @@ module.exports = function(passport) {
 
   // use linkedin strategy
   passport.use(new LinkedinStrategy({
-      consumerKey: config.linkedin.clientID,
-      consumerSecret: config.linkedin.clientSecret,
+      clientID: config.linkedin.clientID,
+      clientSecret: config.linkedin.clientSecret,
       callbackURL: config.linkedin.callbackURL,
-      profileFields: ['id', 'first-name', 'last-name', 'email-address']
+      state: true,
+      scope: ['r_emailaddress', 'r_basicprofile']
     },
     function(accessToken, refreshToken, profile, done) {
       User.findOne({


### PR DESCRIPTION
1. update to use `passport-linkedin-oauth2` instead (which is active maintained)
2. fixes re-login with 3rd parties
3. add "faked email" to twitter