### PR TITLE
HOTFIX: fixes the aggregation on development

### DIFF
--- a/config/env/development.js
+++ b/config/env/development.js
@@ -4,7 +4,7 @@ module.exports = {
   db: 'mongodb://' + (process.env.DB_PORT_27017_TCP_ADDR || 'localhost') + '/mean-dev',
   debug: true,
 //  aggregate: 'whatever that is not false, because boolean false value turns aggregation off', //false
-  aggregate: true,
+  aggregate: false,
   mongoose: {
     debug: false
   },

--- a/config/express.js
+++ b/config/express.js
@@ -66,7 +66,7 @@ module.exports = function(app, passport, db) {
   // Import the assets file and add to locals
   var assets = assetmanager.process({
     assets: require('./assets.json'),
-    debug: !config.aggregate,
+    debug: !(config.aggregate||false),
     webroot: /public\/|packages\//g
   });
   for(var i in assets.core.css){


### PR DESCRIPTION
fixes #996: default aggregate=false on dev env.

The problem caused because the aggregate required creating first the aggregated files using the grunt/gulp(which decide by the environment name, and not the value on the config).

#989 fixed the behaviour wrong behaviour(aggregation set on express by env. too), which reveal the bug in the grunt too.