### PR TITLE
Fixed typo on initial installation homepage

### DIFF
--- a/packages/system/public/views/index.html
+++ b/packages/system/public/views/index.html
@@ -49,7 +49,7 @@
         </div>
         <div class="package">
           <h4><a href="http://mean.io/#!/packages/538180d8a331eb26d1e97d39">Mean-admin</a></h4>
-          <p>Admnister your mean application including user, theme, variable and general settings</p>
+          <p>Administer your mean application including user, theme, variable and general settings</p>
         </div>
         <span class="morelink"><a href="http://mean.io/#!/packages">All Packages</a></span>
       </div>


### PR DESCRIPTION
As described, changed 'Admnister' to 'Administer'