### PR TITLE
Fixes formatting, grammar, spelling & style errors in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@
 MEAN is a framework for an easy starting point with [MongoDB](http://www.mongodb.org/), [Node.js](http://www.nodejs.org/), [Express](http://expressjs.com/), and [AngularJS](http://angularjs.org/) based applications. It is designed to give you a quick and organized way to start developing MEAN based web apps with useful modules like Mongoose and Passport pre-bundled and configured. We mainly try to take care of the connection points between existing popular frameworks and solve common integration problems.
 ## Prerequisites
 * *MongoDB* - <a href="http://www.mongodb.org/downloads">Download</a> and Install mongodb - <a href="http://docs.mongodb.org/manual">Checkout their manual</a> if you're just starting.
-
 * *Node.js* - <a href="http://nodejs.org/download/">Download</a> and Install Node.js, nodeschool has free <a href=" http://nodeschool.io/#workshoppers">node tutorials</a> to get you started.
 ```
 sudo apt-get install python-software-properties python g++ make
@@ -24,33 +23,34 @@ $ npm install -g grunt-cli
 
 ## Installation
 To start with MEAN install the `mean-cli` package from NPM.
-This will add the *mean* command which lets you interact (install, manage, update ...) your mean based  application.
+This will add the *mean* command which lets you interact (install, manage, update ...) your Mean based application.
 
 ### Install the MEAN CLI
 
 ```bash
-  $ npm install -g mean-cli
-  $ mean init <myApp>
-  $ cd <myApp> && npm install
+$ npm install -g mean-cli
+$ mean init <myApp>
+$ cd <myApp> && npm install
 ```
 
 ### Invoke node with Grunt
 We recommend using [Grunt](https://github.com/gruntjs/grunt-cli) to start the server:
 ```bash
-  $ grunt
+$ grunt
 ```
 If grunt aborts because of JSHINT errors, these can be overridden with the `force` flag:
 ```bash
-  $ grunt -f
+$ grunt -f
 ```
 Alternatively, when not using `grunt` (and for production environments) you can run:
 ```bash
-  $ node server
+$ node server
 ```
 Then, open a browser and go to:
 ```bash
-  http://localhost:3000
+http://localhost:3000
 ```
+
 ### Troubleshooting
 During installation depending on your os and prerequiste versions you may encounter some issues.
 
@@ -63,10 +63,12 @@ Sometimes you may find there is a weird error during install like npm's *Error: 
 ```bash
 $ npm update -g npm
 ```
+
 * Updating Grunt:
 ```bash
 $ npm update -g grunt-cli
 ```
+
 * Updating Bower:
 ```bash
 $ npm update -g bower
@@ -92,6 +94,7 @@ Some of Mean.io dependencies uses [node-gyp](https://github.com/TooTallNate/node
 1. install [Python 2.7.x](https://www.python.org/downloads/)
 2. install [Microsoft Visual Studio C++ 2012 Express](http://www.microsoft.com/ru-ru/download/details.aspx?id=34673)
 3. Run NPM update
+
 ```bash
 $ npm update -g
 ```
@@ -100,17 +103,17 @@ $ npm update -g
 
 ### The MEAN stack
 
-MEAN is an acronym for *M*ongo, *E*xpress.js , *A*ngular.js and *N* ode.js
+MEAN is an acronym for *M*ongo, *E*xpress.js , *A*ngular.js and *N*ode.js
 
 <dl class="dl-horizontal">
 <dt>MongoDB</dt>
 <dd>Go through MongoDB Official Website and proceed to its Great Manual, which should help you understand NoSQL and MongoDB better.</dd>
 <dt>Express</dt>
-<dd>The best way to understand express is through its Official Website, particularly The Express Guide; you can also go through this StackOverflow Thread for more resources.</dd>
+<dd>The best way to understand express is through its Official Website, particularly The Express Guide; you can also go through this StackOverflow thread for more resources.</dd>
 <dt>AngularJS</dt>
-<dd>Angular's Official Website is a great starting point. CodeSchool and google created a <a href="https://www.codeschool.com/courses/shaping-up-with-angular-js">great tutorial</a> for beginners., and the angular videos by <a href="https://egghead.io/">Egghead</a>.</dd>
+<dd>Angular's Official Website is a great starting point. CodeSchool and google created a <a href="https://www.codeschool.com/courses/shaping-up-with-angular-js">great tutorial</a> hreadfor beginners, and the angular videos by <a href="https://egghead.io/">Egghead</a>.</dd>
 <dt>Node.js</dt>
-<dd>Start by going through Node.js Official Website and this StackOverflow Thread, which should get you going with the Node.js platform in no time.</dd>
+<dd>Start by going through Node.js Official Website and this StackOverflow thread, which should get you going with the Node.js platform in no time.</dd>
 </dl>
 
 ### Additional Tools
@@ -123,15 +126,15 @@ MEAN is an acronym for *M*ongo, *E*xpress.js , *A*ngular.js and *N* ode.js
 ## CLI
 ### Overview
 
-The MEAN CLI is a simple Command Line Interface for installing and managing MEAN applications. As a core module of the mean.io project, it provides a number of useful tools to make interaction with your MEAN application easier, with features such as: scaffolding, module creation and admin, status checks, and user management.
+The MEAN CLI is a simple Command Line Interface for installing and managing MEAN applications. As a core module of the Mean.io project, it provides a number of useful tools to make interaction with your MEAN application easier, with features such as: scaffolding, module creation and admin, status checks, and user management.
 ```bash
-  $ mean
-  $ mean --help
-  $ mean help
+$ mean
+$ mean --help
+$ mean help
 ```
   <code>mean help</code> can also be used in conjunction with any command to get more information about that particular functionality. For example, try <code>mean help init</code> to see the options for init
 ```bash
-  $ mean help [command]
+$ mean help [command]
 ```
 ### Users
 
@@ -139,35 +142,35 @@ The MEAN CLI is a simple Command Line Interface for installing and managing MEAN
   <p>For example, the <i>admin</i> role is required to edit tokens.</p>
 
 ```bash
-  $ mean user <email> 
-  $ mean user <email> --addRole <role>; 
-  $ mean user <email> --removeRole <role>; 
+$ mean user <email>
+$ mean user <email> --addRole <role>;
+$ mean user <email> --removeRole <role>;
 ```
 
-### packages
+### Packages
 #### Management
  <p class="alert alert-warning">All of the remaining of the commands must be run from the root folder of your MEAN application.</p>
   <p>Contributed MEAN packages can be installed or uninstalled via the CLI. Also, currently installed modules can be viewed with the <code>list</code> command.</p>
 
 ```bash
-  $ mean list
-  $ mean install <module>
-  $ mean uninstall <module>
+$ mean list
+$ mean install <module>
+$ mean uninstall <module>
 ```
 
   <p class="alert alert-info">Mean packages installed via the installer are found in <i>/node_modules</i></p>
 #### Search
 To find new packages run the *mean search* command
 ```bash
-  $ mean search [packagename]
+$ mean search [packagename]
 ```
-mean search will return all of the available packages, mean search packagename will filter the search results.
+`mean search` will return all of the available packages, `mean search packagename` will filter the search results.
 
 #### Scaffolding
 To create a new MEAN app, run <code>mean init</code>. Name for the application is optional. If no name is provided, "mean" is used. The MEAN project will be cloned from GitHub into a directory of the application name.
 ```bash
-  $ mean init [name]
-  $ cd [name] && npm install
+$ mean init [name]
+$ cd [name] && npm install
 ```
   <p class="alert alert-info">Note: <a href="http://git-scm.com/downloads">git</a> must be installed for this command to work properly.</p>
 
@@ -175,12 +178,12 @@ To create a new MEAN app, run <code>mean init</code>. Name for the application i
 <h4>Status</h4>
 <p>Check the database connection for a particular environment (e.g. development (default), test, production) and make sure that the meanio command line version is up to date.</p>
 ```bash
-  $ mean status
+$ mean status
 ```
 <h4>Docs</h4>
 <p>A simple shortcut to open the mean documentation in your default browser.</p>
 ```bash
-  $ mean docs
+$ mean docs
 ```
 
 ## Packages
@@ -189,13 +192,13 @@ Everything in mean.io is a package and when extending mean with custom functiona
 
 The mean.io package system allows developers to create modular code that provides useful tools that other mean developers can use. The packages, when published, are plug-and-play and are used in a way very similar to traditional npm packages.
 
-The meanio package system integrates all the packages into the mean project as if the code was part of mean itself and provides the developers with all the necceesary tools required to integrate their package into the host project.
+The mean.io package system integrates all the packages into the mean project as if the code was part of mean itself and provides the developers with all the necceesary tools required to integrate their package into the host project.
 
 There are two types of packages:
 
-**Custom Packages** are generated by the mean scaffolder and contain most of your application logic. Custom packages are found in /packages/custom and can be published as a contrib package for use by other developers.
+**Custom Packages** are generated by the mean scaffolder and contain most of your application logic. Custom packages are found in */packages/custom* and can be published as a contrib package for use by other developers.
 
-**Contrib Packages** are installed by the mean installer and are found at /packages/contrib. Contrib packages are "plug and play".
+**Contrib Packages** are installed by the mean installer and are found at */packages/contrib*. Contrib packages are "plug and play".
 
 ### Core Packages
 
@@ -203,15 +206,15 @@ All `Core` packages can be overridden by other packages allowing you to extend a
 
 
 #### System
-The system package creates the basic pages as well as defines the layout of the site and integrates the menu into the page. The system package also allows us to define things such as rendering engines, static files and routing on the client and server side.
+The "system" package creates the basic pages as well as defines the layout of the site and integrates the menu into the page. The system package also allows us to define things such as rendering engines, static files and routing on the client and server side.
 #### Users
-The users package creates the database model of the user, provides validation as well as various login and registration features.
+The "users" package creates the database model of the user, provides validation as well as various login and registration features.
 #### Access
-The access package managers permissions and middleware. It controls the various authentication methods and is dependent on the users package
+The "access" package managers permissions and middleware. It controls the various authentication methods and is dependent on the users package
 #### Theme
-The theme package adds some basic CSS and other assets such as images and backgrounds
+The "theme" package adds some basic CSS and other assets such as images and backgrounds
 #### Articles
-Articles package is typically used as an example, starting point for managing content that might be used in a blog or cms. The full CRUD is implemented on the server and client.
+The "articles" package is typically used as an example starting point for managing content that might be used in a blog or cms. The full CRUD is implemented on the server and client.
 ### Files structure
 The file structure is similar to that of the mean project itself
 
@@ -252,13 +255,17 @@ In order for a Package to work it needs to be registered. By doing this you make
 
 When registering you are required to declare all your dependencies in order for the package system to make them available to your package.
 
+```javascript
+// Example of registering the MyPackage
+MyPackage.register(function(app, auth, database) {
+  // ...
+});
+```
 
-    // Example of registering the MyPackage
-    MyPackage.register(function(app, auth, database) {
-    
-    });
-
-MEAN has 3 pre registered dependencies. `app` which makes the express app available `auth` which has some basic authentication functions and `database` which contains the mongoose database connection.<
+MEAN has 3 pre registered dependencies:
+  - `app` Makes the express app available .
+  - `auth` Includes some basic authentication functions
+  - `database` Contains the Mongoose database connection
 
 > All dependencies specified must be registered in order to use them
 
@@ -274,20 +281,20 @@ MEAN has 3 pre registered dependencies. `app` which makes the express app availa
 Dependency injection allows you to declare what dependencies you require and rely on the package system to resolve all dependencies for you. Any package registered is automatically made available to anyone who would like to depend on them.
 
 Looking again at the registration example we can see that `MyPackage` depends on the `Tokens` and can make use of it full functionality including overriding it.
-
  
+```javascript
+// Example of registering the tokens package
+MyPackage.register(function(app, auth, database, Tokens) {
 
-    // Example of registering the tokens package
-     MyPackage.register(function(app, auth, database, Tokens) {
+  // I can make use of the tokens within my module
+   MyPackage.someExampleFunction('some paramater');
 
-    //I can make use of the tokens within my module
-       MyPackage.someExampleFunction('some paramater');
-
-    //I can override functions
-    MyPackage.someExampleFunction = function(param) {
-      //my custom logic goes here
-    };
-  });
+  // I can override functions
+  MyPackage.someExampleFunction = function(param) {
+    //my custom logic goes here
+  };
+});
+```
 
 > Packages when in code are used in a capitalized form
 
@@ -301,27 +308,32 @@ In addition you are able to declare which angular dependencies you want your ang
 
 Below is an example of adding an angular dependency to our angular module.
 
-      // Example of adding an angular dependency of the ngDragDrop to the
-      MyPackage.angularDependencies(['ngDragDrop']);
+```javascript
+// Example of adding an angular dependency of the ngDragDrop to the
+MyPackage.angularDependencies(['ngDragDrop']);
+```
 
 > See the assets section for an example how to add external libraries to
 > the client such as the `gDragDrop `javascript library
 
 ###Assets and Aggregation
 
-All assets such as images, javascript libraries and css stylesheets should be within `public/assets` of the package file structure.
+All assets such as images, javascript libraries and CSS stylesheets should be within `public/assets` of the package file structure.
 
-Javascript and css from `assets` can be aggregated to the global aggregation files. By default all javascript is automatically wrapped within an anonymous function unless given the option `{global:true}` to not enclose the javascript within a contained scope
+Javascript and CSS from `assets` can be aggregated to the global aggregation files. By default all javascript is automatically wrapped within an anonymous function unless given the option `{global:true}` to not enclose the javascript within a contained scope
 
-      //Adding jquery to the mean project
-      MyPackage.aggregateAsset('js','jquery.min.js');
-    
-      //Adding another library - global by default is false
-      MyPackage.aggregateAsset('js','jquery.min.js', {global:true});
-    
-      //Adding some css to the mean project
-      MyPackage.aggregateAsset('css','default.css');
 
+```javascript
+
+//Adding jquery to the mean project
+MyPackage.aggregateAsset('js','jquery.min.js');
+
+//Adding another library - global by default is false
+MyPackage.aggregateAsset('js','jquery.min.js', {global:true});
+
+//Adding some css to the mean project
+MyPackage.aggregateAsset('css','default.css');
+```
 
 > Javascript files outside of assets are automatically aggregated and
 > injected into the mean project. As a result libraries that you do not
@@ -329,7 +341,10 @@ Javascript and css from `assets` can be aggregated to the global aggregation fil
 
 The aggregation supports the ability to control the location of where to inject the aggregated code and if you add a weight and a group to your aggregateAsset method you can make sure it's included in the correct region.
 
-      MyPackage.aggregateAsset('js','first.js',{global:true,  weight: -4, group: 'header'});
+```javascript
+MyPackage.aggregateAsset('js','first.js',{global:true,  weight: -4, group: 'header'});
+```
+
 >The line that gets loaded in your head.html calls the header group and injects the js you want to include first-
 > in packages/system/server/views/includes/head.html 
 > <script type="text/javascript" src="/modules/aggregated.js?group=header"></script>
@@ -339,19 +354,20 @@ The settings object is a persistance object that is stored in the packages colle
 
   Receives two arguments the first being the settings object the second is a callback function
   
+```javascript
+MyPackage.settings({'someSetting':'some value'}, function (err, settings) {
+    //you will receive the settings object on success
+});
 
-    MyPackage.settings({'someSetting':'some value'},function (err, settings) {
-        //you will receive the settings object on success
-    });
+// Another save settings example this time with no callback
+// This writes over the last settings.
+MyPackage.settings({'anotherSettings':'some value'});
 
-    // Another save settings example this time with no callback
-    // This writes over the last settings.
-    MyPackage.settings({'anotherSettings':'some value'});
-
-    // Get settings. Retrieves latest saved settings
-    MyPackage.settings(function (err, settings) {
-      //you now have the settings object
-    });
+// Get settings. Retrieves latest saved settings
+MyPackage.settings(function (err, settings) {
+  //you now have the settings object
+});
+```
 
 > Each time you save settings you overwrite your previous value.
 > Settings are designed to be used to store basic configuration options
@@ -361,49 +377,54 @@ The settings object is a persistance object that is stored in the packages colle
 ###Express Routes
 All routing to server side controllers is handled by express routes. The package system uses the typical express approach. The package system has a route function that passes along the package object to the main routing file typically `server/routes/myPackage.js`
 
-  By default the Package Object is passed to the routes along withe the other arguments
-  MyPackage.routes(app, auth, database);
+  By default the Package Object is passed to the routes along with the other arguments
+  `MyPackage.routes(app, auth, database);`
 
 
 Example from the `server/routes/myPackage.js`
 
-      // The Package is past automatically as first parameter
-      module.exports = function(MyPackage, app, auth, database) {
-    
-      //example route
-      app.get('/myPackage/example/anyone', function (req,res,next) {
-        res.send('Anyone can access this');
-      });
-    
-    };
+```javascript
+// The Package is past automatically as first parameter
+module.exports = function(MyPackage, app, auth, database) {
+
+  // example route
+  app.get('/myPackage/example/anyone', function (req,res,next) {
+    res.send('Anyone can access this');
+  });
+};
+```
 
 ###Angular Routes
 The angular routes are defined in `public/routes/myPackage.js`. Just like the latest version of mean, the packages  use the `$stateProvider`
 
-      $stateProvider
-        .state('myPackage example page', {
-          url: '/myPackage/example',
-          templateUrl: 'myPackage/views/index.html'
-        });
+```javascript
+$stateProvider
+  .state('myPackage example page', {
+    url: '/myPackage/example',
+    templateUrl: 'myPackage/views/index.html'
+  });
+```
 
 > The angular views are publically accessible via templateUrl when
 > prefixed with the package name
 
 ###Menu System
 
-Packages are able to hook into an existing menu system and add links to various menus integrated within mean.
+Packages are able to hook into an existing menu system and add links to various menus integrated within Mean.
 
 Each link specifies its `title`, `template`, `menu` and `role` that is allowed to see the link. If the menu specified does not exist a new menu will be created. The menu object is made accessible within the client by means of a *menu angular service* that queries the menu controller for information about links.
 
 Below is an example how to add a link to the main menu from `app.js`
 
-      //We are adding a link to the main menu for all authenticated users
-      MyPackage.menus.add({
-        title: "myPackage example page",
-        link: "myPackage example page",
-        roles: ["authenticated"],
-        menu: "main"
-      });
+```javascript
+//We are adding a link to the main menu for all authenticated users
+MyPackage.menus.add({
+  title: "myPackage example page",
+  link: "myPackage example page",
+  roles: ["authenticated"],
+  menu: "main"
+});
+```
 
 
 > You can look at the angular header controller in the mean project for
@@ -411,17 +432,17 @@ Below is an example how to add a link to the main menu from `app.js`
 > see how the menu service is implemented
 
 ###Html View Rendering
-The packages come built in with a rendering function allowing packages to render static html. The default templating engine is *swig*. The views are found in `server/views` of the package and should end with the .html suffix
+The packages come built in with a rendering function allowing packages to render static html. The default templating engine is *swig*. The views are found in `server/views` of the package and should end with the `.html` suffix
 
 Below is an example rendering some simple html
 
-```
-  app.get('/myPackage/example/render', function (req,res,next) {
-    MyPackage.render('index', {packageName:'myPackage'}, function (err, html) {
-      //Rendering a view from the Package server/views
-      res.send(html);
-    });
+```javascript
+app.get('/myPackage/example/render', function (req,res,next) {
+  MyPackage.render('index', {packageName:'myPackage'}, function (err, html) {
+    //Rendering a view from the Package server/views
+    res.send(html);
   });
+});
 ```
 
 ###Overriding the default layouts
@@ -429,8 +450,11 @@ One is able to override the default layout of the application through a custom p
 
 Below is an example overriding the default layout of system and instead using the layourts found locally within the package
 
-    MyPackage.register(function(system, app) {
-      app.set('views', __dirname + '/server/views');
+```javascript
+MyPackage.register(function(system, app) {
+  app.set('views', __dirname + '/server/views');
+  // ...
+```
 
 > Please note that the package must depend on `System` to ensure it is
 > evaluated after `System` and can thus override the views folder
@@ -438,20 +462,22 @@ Below is an example overriding the default layout of system and instead using th
 ### Overriding views
 You may override public views used by certain core packages.  To create a custom home page, you would create a custom package and modify the script in it's public folder like so:
 
-```
+```javascript
 angular.module('mean.mycustompackage', ['mean.system'])
-  .config(['$viewPathProvider', function($viewPathProvider) {
-    $viewPathProvider.override('system/views/index.html', 'mycustompackage/views/myhomepage.html');
-  }]);
+.config(['$viewPathProvider', function($viewPathProvider) {
+  $viewPathProvider.override('system/views/index.html', 'mycustompackage/views/myhomepage.html');
+}]);
 ```
 
 This will render *mycustompackage/views/myhomepage.html* as the home page.
 
 ### Creating your own package
-To create your own package and scaffold it's initial code - run
+To create your own package and scaffold its initial code, run the following command:
+
 ```bash
 mean package <packageName>
 ```
+
 This will create a package under */packages/custom/pkgName*
 
 ### Deleting a package
@@ -466,17 +492,19 @@ Where "myPackage" is the name of your package.
 ### Contributing your package
 Once your package is in good shape and you want to share it with the world you can start the process of contributing it and submiting it so it can be included in the package repository.
 To contribute your package register to the network (see the section below) and run
+
 ```bash 
-mean register // register to the mean network (see below)
-cd packages/custom/pkgNName>
+mean register # register to the mean network (see below)
+cd <packages/custom/pkgName>
 mean publish
 ```
+
 ## MEAN Network
-Mean is stand-alone instance that you can install locally or host on your server.  
+Mean is a stand-alone instance that you can install locally or host on your server.
 We want to provide value to developers and are assembling a set of services which will be called the mean network.
 We're building all of this as we speak but we allready have some elements in place.
 
-### Network User management
+### Network User Management
 
 #### Registration
 ```bash
@@ -523,15 +551,15 @@ Each of these environments has the following configuration options:
 
 To run with a different environment, just specify NODE_ENV as you call grunt:
 ```bash
-    $ NODE_ENV=test grunt
+$ NODE_ENV=test grunt
 ```
 If you are using node instead of grunt, it is very similar:
 ```bash
-    $ NODE_ENV=test node server
+$ NODE_ENV=test node server
 ```
 To simply run tests
 ```bash
-    $ npm test
+$ npm test
 ```
 > NOTE: Running Node.js applications in the __production__ environment enables caching, which is disabled by default in all other environments.
 
@@ -561,14 +589,14 @@ To do so all you need to do is the following steps.
 1. Run ```mean deploy```
 1. It will create the meanio remote which can be used to update your remote app by ```git push meanio master```
 1. You can add remote command using the --remote flag for instance to add a role to a user on the remote cloud instance run ```mean user -a RoleName emailAddress --remote```
-1. To get an idea of whats happening on the mean log (node.js based logging) run ```mean logs -n 100` to get the last 100 lines...
+1. To get an idea of whats happening on the mean log (node.js based logging) run ```mean logs -n 100``` to get the last 100 lines...
 
 ### Heroku
 Before you start make sure you have the [Heroku toolbelt](https://toolbelt.heroku.com/)
 installed and an accessible MongoDB instance - you can try [MongoHQ](http://www.mongohq.com/)
 which has an easy setup).
 
-Add the db string to the production env in server/config/env/production.js.
+Add the db string to the production env in *server/config/env/production.js*.
 
 ```bash
 git init
@@ -584,8 +612,8 @@ heroku config:set NODE_ENV=production
 ### OpenShift
 
 1. Register for an account on Openshift (http://www.openshift.com).
-1. Create an app on Openshift by choosing a 'Node' type site to create. Create the site by making Openshift use Linnovate's Openshift git repo as its source code (https://github.com/linnovate/mean-on-openshift.git)
-1. On the second screen after the new application has been created, add a Mongo database
+1. Create an app on Openshift by choosing a 'Node' type site to create. Create the site by making Openshift use Linnovate's Openshift git repo as its source code (https://github.com/linnovate/mean-on-openshift.git).
+1. On the second screen after the new application has been created, add a Mongo database.
 1. When the site has been built, you can visit it on your newly created domain, which will look like my-domain.openshift.com. You may need to restart the instance on Openshift before you can see it. It will look like Mean.io boilerplate.
 1. On your new app's console page on Openshift, make a note of the git repo where the code lives. Clone that repo to your local computer where your mean.io app codebase is.
 1. Merge your completed local app into this new repo. You will have some conflicts, so merge carefully, line by line.
@@ -599,9 +627,9 @@ heroku config:set NODE_ENV=production
 ## Credits
   * To our awesome <a href="https://github.com/orgs/linnovate/teams/mean">core team</a> with help of our <a href="https://github.com/linnovate/mean/graphs/contributors">contributors</a> which have made this project a success.
   * <a href="https://github.com/vkarpov15">Valeri Karpov</a> for coining the term *mean* and triggering the mean stack movement.
-  * <a href="https://github.com/amoshaviv">Amos Haviv</a>  for the creation of the initial version of mean.io while working for us @linnovate.
+  * <a href="https://github.com/amoshaviv">Amos Haviv</a>  for the creation of the initial version of Mean.io while working for us @linnovate.
   * <a href="https://github.com/madhums/">Madhusudhan Srinivasa</a> which inspired us with his great work.
 
 ## License
-We belive that mean should be free and easy to integrate within your existing projects so we chose the [The MIT License](http://opensource.org/licenses/MIT)
+We believe that mean should be free and easy to integrate within your existing projects so we chose [The MIT License](http://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
There existed several small typographical, grammar errors along with some formatting and style inconsistencies within the Readme. This pull request fixes those right up and also adds syntax hi lighting to the javascript examples. A preview of the cleaned up version can be seen on the homepage of the forked repo: https://github.com/Aerlinger/mean.

Please let me know if any amendments or further corrections are necessary.