### PR TITLE
Update articles.js

### DIFF
--- a/packages/articles/public/routes/articles.js
+++ b/packages/articles/public/routes/articles.js
@@ -16,7 +16,7 @@ angular.module('mean.articles').config(['$stateProvider',
         // Not Authenticated
         else {
           $timeout(deferred.reject);
-          $location.url('/login');
+          $location.url('/auth/login');
         }
       });
 


### PR DESCRIPTION
The redirect location when '/loggedin' fail should be '/auth/login'