### PR TITLE
Update README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This will add the *mean* command which lets you interact (install, manage, updat
 ```bash
 $ npm install -g mean-cli
 $ mean init <myApp>
-$ cd <myApp> && npm install
+$ cd <myApp> && bower install && npm install
 ```
 
 ### Invoke node with Grunt


### PR DESCRIPTION
If we launch the command grunt with the bower components not installed, we have the error described in this issue : #1003

It's important to install the components, then to install packages. 
That's why we should add bower install in the README.md