### PR TITLE
removed unused gulp-rimraf import

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "gulp-load-plugins": "^0.7.0",
     "gulp-mocha": "^1.1.0",
     "gulp-nodemon": "^1.0.4",
-    "gulp-rimraf": "^0.1.1",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "jshint-stylish": "^1.0.0",

--- a/tools/gulp/gulp.json
+++ b/tools/gulp/gulp.json
@@ -11,7 +11,6 @@
     "gulp-load-plugins": "^0.7.0",
     "gulp-mocha": "^1.1.0",
     "gulp-nodemon": "^1.0.4",
-    "gulp-rimraf": "^0.1.1",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
     "jshint-stylish": "^1.0.0",


### PR DESCRIPTION
gulp-rimraf is deprecated and is not used in the gulfile.
the import seems to be a leftover from the past.