### PR TITLE
Add 'gulp help' command to show available tasks

### DIFF
--- a/tools/gulp/gulp.json
+++ b/tools/gulp/gulp.json
@@ -14,6 +14,7 @@
     "gulp-rimraf": "^0.1.1",
     "gulp-uglify": "^1.0.1",
     "gulp-util": "^3.0.1",
+    "gulp-task-listing": "1.0.0",
     "jshint-stylish": "^1.0.0",
     "through": "^2.3.6"
   }

--- a/tools/gulp/gulpfile.js
+++ b/tools/gulp/gulpfile.js
@@ -42,6 +42,11 @@ function tokenizeConfig(config) {
   };
 }
 
+/** 
+ * gulp help - show available gulp commands
+ */
+gulp.task('help', plugins.taskListing);
+
 gulp.task('csslint', function () {
   return gulp.src(paths.css)
     .pipe(plugins.csslint('.csslintrc'))


### PR DESCRIPTION
Hey, this is a drive-by pull request for gulp.  This adds a command 'gulp help' that shows available tasks in the gulp file.  It's some sugar.

E.g.
```
michael@mc-laptop ~/cm/cm_www:  gulp help                                                                                                  
[11:29:35] Using gulpfile ~/cm/cm_www/gulpfile.js
[11:29:35] Starting 'help'...

Main Tasks
------------------------------
    clean
    csslint
    cssmin
    default
    develop
    help
    jshint
    less
    loadTestSchema
    mochaTest
    test
    uglify
    watch

Sub Tasks
------------------------------
    env:develop
    env:production
    env:test
    heroku:production
    karma:unit

[11:29:35] Finished 'help' after 1.33 ms
```
