### PR TITLE
Better logs for mean apps

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -33,10 +33,10 @@ module.exports = function(app, db) {
   // Enable compression on bower_components
   app.use('/bower_components', express.static(config.root + '/bower_components'));
 
-  // Only use logger for development environment
-  if (process.env.NODE_ENV === 'development') {
-    app.use(morgan('dev'));
-  }
+  //if (process.env.NODE_ENV === 'development') {
+    app.enable('trust proxy'); // Log Real IP (X-Forwarded-For)
+    app.use(morgan('combined')); // Use detailed format, logstash ready
+  //}
 
   // assign the template engine to .html files
   app.engine('html', consolidate[config.templateEngine]);


### PR DESCRIPTION
Changed the default format of logs from "dev" to "combined", so that we have better server side logs, and so that it will be easier to analyse logs with the ELK stack.
See https://www.npmjs.com/package/morgan for formats details.

Also added the REAL-IP to the logs, since in many cases express runs behind a proxy.