### PR TITLE
cleaning up commented if() and disabling 'trust proxy' in express

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -33,10 +33,7 @@ module.exports = function(app, db) {
   // Enable compression on bower_components
   app.use('/bower_components', express.static(config.root + '/bower_components'));
 
-  //if (process.env.NODE_ENV === 'development') {
-    app.enable('trust proxy'); // Log Real IP (X-Forwarded-For)
-    app.use(morgan('combined')); // Use detailed format, logstash ready
-  //}
+  app.use(morgan('combined')); // Use detailed format, logstash ready
 
   // assign the template engine to .html files
   app.engine('html', consolidate[config.templateEngine]);


### PR DESCRIPTION
removing commented if() which is obsolete and express configuration to enable trust proxy support which will allow attackers to spoof their IPs and logs will be unable to reveal that