### PR TITLE
Fix for angular-jwt injecting authorization header

### DIFF
--- a/packages/core/admin/public/controllers/themes.js
+++ b/packages/core/admin/public/controllers/themes.js
@@ -8,7 +8,8 @@ angular.module('mean.admin').controller('ThemesController', ['$scope', 'Global',
         $scope.init = function() {
             $http({
                 method: 'GET',
-                url: 'http://api.bootswatch.com/3/'
+                url: 'http://api.bootswatch.com/3/',
+                skipAuthorization: true
             }).
             success(function(data, status, headers, config) {
                 $scope.themes = data.themes;


### PR DESCRIPTION
Fixes: XMLHttpRequest cannot load http://api.bootswatch.com/3/. Request header field Authorization is not allowed by Access-Control-Allow-Headers.  Which doesn't allow themes to display.