### PR TITLE
Fix i18n package requiring bower dependencies

### DIFF
--- a/packages/custom/i18n/package.json
+++ b/packages/custom/i18n/package.json
@@ -10,6 +10,9 @@
     "node": "0.10.x",
     "npm": "1.4.x"
   },
+  "scripts": {
+    "postinstall": "bower install"
+  },
   "dependencies": {},
   "license": "MIT"
 }


### PR DESCRIPTION
A quick fix to allow i18n package function on clean installations.

In future postinstall script will be extended so it will also invoke bower install for default packages