### PR TITLE
Fix an error when running gulp test

### DIFF
--- a/gulp/test.js
+++ b/gulp/test.js
@@ -12,7 +12,9 @@ gulp.task('karma:unit', function (done) {
   karma.start({
     configFile: __dirname + '/../karma.conf.js',
     singleRun: true
-  }, done);
+  }, function () {
+    done();
+  });
 });
 
 gulp.task('loadTestSchema', function () {


### PR DESCRIPTION
This commit fixed the test fail when running `gulp test`, which is described in #1217. The error came from error handling in `gulp`. 

[More details](http://stackoverflow.com/questions/26614738/issue-running-karma-task-from-gulp). 