### PR TITLE
Made admin menus accessible to other packages

### DIFF
--- a/packages/core/admin/app.js
+++ b/packages/core/admin/app.js
@@ -13,12 +13,43 @@ var Admin = new Module('admin');
 
 Admin.register(function(app, auth, database) {
 
-	Admin.menus.add({
-		title: 'admin settings',
-		link: 'admin settings',
-		roles: ['admin'],
-		menu: 'main'
-	});
+    var icons = 'admin/assets/img/icons/';
+
+    Admin.menus.add({
+        title: 'admin settings',
+        link: 'admin settings',
+        roles: ['admin'],
+        menu: 'main'
+    });
+
+    Admin.menus.add({
+        roles: ['admin'],
+        title: 'MODULES',
+        link: 'modules',
+        icon: icons + 'modules.png',
+        menu: 'admin'
+    });
+    Admin.menus.add({
+        roles: ['admin'],
+        title: 'THEMES',
+        link: 'themes',
+        icon: icons + 'themes.png',
+        menu: 'admin'
+    });
+    Admin.menus.add({
+        roles: ['admin'],
+        title: 'SETTINGS',
+        link: 'settings',
+        icon: icons + 'settings.png',
+        menu: 'admin'
+    });
+    Admin.menus.add({
+        roles: ['admin'],
+        title: 'USERS',
+        link: 'users',
+        icon: icons + 'users.png',
+        menu: 'admin'
+    });
 
     Admin.aggregateAsset('css', 'admin.css');
     Admin.aggregateAsset('js', '../lib/ng-clip/src/ngClip.js', {

--- a/packages/core/admin/public/controllers/admin.js
+++ b/packages/core/admin/public/controllers/admin.js
@@ -6,30 +6,8 @@ angular.module('mean.admin').controller('AdminController', ['$scope', 'Global', 
         $scope.menus = {};
         $scope.overIcon = false;
         $scope.user = MeanUser;
-        var icons = 'admin/assets/img/icons/';
-        
-        // Default hard coded menu items for main menu
-        var defaultAdminMenu = [{
-            'roles': ['admin'],
-            'title': 'MODULES',
-            'link': 'modules',
-            'icon': icons + 'modules.png'
-        }, {
-            'roles': ['admin'],
-            'title': 'THEMES',
-            'link': 'themes',
-            'icon': icons + 'themes.png'
-        }, {
-            'roles': ['admin'],
-            'title': 'SETTINGS',
-            'link': 'settings',
-            'icon': icons + 'settings.png'
-        }, {
-            'roles': ['admin'],
-            'title': 'USERS',
-            'link': 'users',
-            'icon': icons + 'users.png'
-        }];
+
+        var defaultAdminMenu = [];
 
         // Query menus added by modules. Only returns menus that user is allowed to see.
         function queryMenu(name, defaultMenu) {


### PR DESCRIPTION
This allows other packages to access the admin menus so they can render them themselves and themes can omit the sidebar admin menu if they want.

An example of adding the Admin menu as a dropdown on the header bar is, (in your theme's views/header.html, if you follow the custom theme structure):
```
// within the ul navbar-nav, after other menu items have been rendered
<li ng-if="hdrctr.menus.admin.length > 0" class="dropdown" dropdown>
  <a href class="dropdown-toggle" dropdown-toggle>Admin</a>
  <ul class="dropdown-menu">
    <li ng-repeat="item in hdrctr.menus.admin">
      <a mean-token="item.link" ui-sref='{{item.link}}'>{{item.title}}</a>
    </li>
  </ul>
</li>
```
in the header controller
```
queryMenu('admin', defaultMenu);
```