### PR TITLE
Re-enabled livereload in development environment

### DIFF
--- a/gulp/development.js
+++ b/gulp/development.js
@@ -47,29 +47,38 @@ gulp.task('less', function() {
 });
 
 gulp.task('devServe', ['env:development'], function () {
+
   plugins.nodemon({
     script: 'server.js',
     ext: 'html js',
     env: { 'NODE_ENV': 'development' } ,
     ignore: ['node_modules/'],
-    nodeArgs: ['--debug']
+    nodeArgs: ['--debug'],
+    stdout: false
+  }).on('readable', function(data) {
+    this.stdout.on('data', function(chunk) {
+      if(/Mean app started/.test(chunk)) {
+        setTimeout(function() { plugins.livereload.reload() }, 500);
+      }
+      process.stdout.write(chunk);
+    });
+    this.stderr.pipe(process.stderr);
   });
 });
 
 gulp.task('coffee', function() {
   gulp.src(paths.coffee)
     .pipe(coffee({bare: true}).on('error', gutil.log))
-    .pipe(gulp.dest('./packages'))
+    .pipe(gulp.dest('./packages'));
 });
 
 gulp.task('watch', function () {
-  gulp.watch(paths.coffee,['coffee']).on('change', plugins.livereload.changed);
-  gulp.watch(paths.coffees).on('change',plugins.livereload.changed);
-  gulp.watch(paths.js, ['jshint']).on('change', plugins.livereload.changed);
-  gulp.watch(paths.html).on('change', plugins.livereload.changed);
+  plugins.livereload.listen({interval:500});
+
+  gulp.watch(paths.coffee,['coffee']);
+  gulp.watch(paths.js, ['jshint']);
   gulp.watch(paths.css, ['csslint']).on('change', plugins.livereload.changed);
-  gulp.watch(paths.less, ['less']).on('change', plugins.livereload.changed);
-  plugins.livereload.listen({interval: 500});
+  gulp.watch(paths.less, ['less']);
 });
 
 function count(taskName, message) {

--- a/gulp/development.js
+++ b/gulp/development.js
@@ -55,10 +55,10 @@ gulp.task('devServe', ['env:development'], function () {
     ignore: ['node_modules/'],
     nodeArgs: ['--debug'],
     stdout: false
-  }).on('readable', function(data) {
+  }).on('readable', function() {
     this.stdout.on('data', function(chunk) {
       if(/Mean app started/.test(chunk)) {
-        setTimeout(function() { plugins.livereload.reload() }, 500);
+        setTimeout(function() { plugins.livereload.reload(); }, 500);
       }
       process.stdout.write(chunk);
     });

--- a/packages/core/system/server/views/includes/foot.html
+++ b/packages/core/system/server/views/includes/foot.html
@@ -3,9 +3,5 @@
 {% endfor %}
 
 {% if (process.env.NODE_ENV == 'development') %}
-  <!-- Livereload script rendered -->
-  <!-- Disabling livereload due to - https://github.com/linnovate/mean/issues/929
-       Will probably return in 0.4.2 and new aggregation
   <script type="text/javascript" src="{{'//' + req.hostname + ':35729/livereload.js'}}"></script>
-  -->
 {% endif %}


### PR DESCRIPTION
Moved livereload watching away from anything that results in html or js changes, since these will cause the server to restart (and you'd end up reloading the pages during the restart process).

Instead, the server output is watched for 'Mean app started' and reloads when that comes up in stdout.  CSS is the only thing still watched (less will result in css changes and everything else in html or js).

The 500ms wait is consistantly long enough for not reload just as the server is coming up.  Shorter is probably possible but 500ms isn't noticable.