### PR TITLE
#1262 Prevent a default angular redirect to '/' after logging in as i…

### DIFF
--- a/packages/core/users/public/services/meanUser.js
+++ b/packages/core/users/public/services/meanUser.js
@@ -69,8 +69,6 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
         if (destination) {
           $location.path(destination.replace(/^"|"$/g, ''));
           $cookieStore.remove('redirect');
-        } else {
-          $location.url('/');
         }
       } else {
         this.user = response;


### PR DESCRIPTION
…t inhibits any regular redirects (which all OAuth callback endpoints, at least, appear to do anyway)