### PR TITLE
Bugfix/1264 twitter express session

### DIFF
--- a/config/express.js
+++ b/config/express.js
@@ -9,6 +9,7 @@ var mean = require('meanio'),
   morgan = require('morgan'),
   consolidate = require('consolidate'),
   express = require('express'),
+  session = require('express-session'),
   helpers = require('view-helpers'),
   flash = require('connect-flash'),
   modRewrite = require('connect-modrewrite'),
@@ -45,6 +46,8 @@ module.exports = function(app, db) {
   // set .html as the default extension
   app.set('view engine', 'html');
 
+  // Session support
+  app.use(session({ secret: config.secret }));
 
   // Dynamic helpers
   app.use(helpers(config.app.name));

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -2317,6 +2317,65 @@
         },
         "utils-merge": {
           "version": "1.0.0",
+          "from": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        }
+      }
+    },
+    "express-session": {
+      "version": "1.11.3",
+      "from": "express-session@*",
+      "resolved": "https://registry.npmjs.org/express-session/-/express-session-1.11.3.tgz",
+      "dependencies": {
+        "cookie": {
+          "version": "0.1.3",
+          "from": "cookie@0.1.3",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.3.tgz"
+        },
+        "cookie-signature": {
+          "version": "1.0.6",
+          "from": "cookie-signature@1.0.6",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+        },
+        "crc": {
+          "version": "3.3.0",
+          "from": "crc@3.3.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.3.0.tgz"
+        },
+        "debug": {
+          "version": "2.2.0",
+          "from": "debug@>=2.2.0 <2.3.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
+        },
+        "depd": {
+          "version": "1.0.1",
+          "from": "depd@>=1.0.1 <1.1.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.1.tgz"
+        },
+        "on-headers": {
+          "version": "1.0.0",
+          "from": "on-headers@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.0.tgz"
+        },
+        "parseurl": {
+          "version": "1.3.0",
+          "from": "parseurl@>=1.3.0 <1.4.0",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+        },
+        "uid-safe": {
+          "version": "2.0.0",
+          "from": "uid-safe@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.0.0.tgz",
+          "dependencies": {
+            "base64-url": {
+              "version": "1.2.1",
+              "from": "base64-url@1.2.1",
+              "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+            }
+          }
+        },
+        "utils-merge": {
+          "version": "1.0.0",
           "from": "utils-merge@1.0.0",
           "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
         }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "cookie-parser": "latest",
     "errorhandler": "latest",
     "express": "latest",
+    "express-session": "latest",
     "forever": "latest",
     "gridfs-stream": "latest",
     "jsonwebtoken": "latest",

--- a/packages/core/users/server/models/user.js
+++ b/packages/core/users/server/models/user.js
@@ -50,7 +50,7 @@ var UserSchema = new Schema({
   },
   email: {
     type: String,
-    required: true,
+    required: false,
     unique: true,
     // Regexp to validate emails with more strict rules as added in tests/users.js which also conforms mostly with RFC2822 guide lines
     match: [/^(([^<>()[\]\\.,;:\s@\"]+(\.[^<>()[\]\\.,;:\s@\"]+)*)|(\".+\"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/, 'Please enter a valid email'],


### PR DESCRIPTION
In addition to requiring express-session, Twitter OAuth is silently failing because mean is requiring an email address. This PR gets Twitter logins working out-of-the-box (except for configuring consumer, keys of course) by change email to a non-required field in Mongoose. Clearly, this has a wider impact but I believe it's benign, and the 'right thing' to do.

One other thing to note - when I run npm shrinkwrap, all the 'from' attributes are updated to use a different format. I assume this is a change in npm behavior (I'm using the latest version - 2.13.0). For the purposes of this PR, I've only committed the hunk that is required.
