### PR TITLE
Moved body class change to successful state change

### DIFF
--- a/packages/core/system/public/system.js
+++ b/packages/core/system/public/system.js
@@ -2,7 +2,7 @@
 
 angular.module('mean.system', ['ui.router', 'mean-factory-interceptor'])
   .run(['$rootScope', function($rootScope) {
-    $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams){
+    $rootScope.$on('$stateChangeSuccess', function(event, toState, toParams, fromState, fromParams){
       var toPath = toState.url;
       toPath = toPath.replace(new RegExp('/', 'g'), '');
       toPath = toPath.replace(new RegExp(':', 'g'),'-');


### PR DESCRIPTION
If a resolve in a route fails, or there is some other $stateChangeStart condition that causes the state to not change, the class applied to the body based on the toState was still being applied.  I changed this to only occur on $stateChangeSuccess.