### PR TITLE
Update for Angular 1.4, fixes linnovate/mean#1262

### DIFF
--- a/packages/core/users/public/services/meanUser.js
+++ b/packages/core/users/public/services/meanUser.js
@@ -63,7 +63,7 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
         var encodedProfile = decodeURI(b64_to_utf8(response.token.split('.')[1]));
         var payload = JSON.parse(encodedProfile);
         this.user = payload;
-        var destination = $cookies.redirect;
+        var destination = $cookies.get('redirect');
         if (this.user.roles.indexOf('admin') !== -1) this.isAdmin = true;
         $rootScope.$emit('loggedin');
         if (destination) {


### PR DESCRIPTION
Fixes non-anonymous route redirection problems.  Previously, clicking a link or entering a url to a protected route would send you to login and redirect to '/' because destination wasn't properly populated with the redirect cookie.