### PR TITLE
added missing to store linkedin profile info

### DIFF
--- a/packages/core/users/passport.js
+++ b/packages/core/users/passport.js
@@ -209,6 +209,7 @@ module.exports = function(passport) {
           email: profile.emails[0].value,
           username: profile.emails[0].value,
           provider: 'linkedin',
+          linkedin: profile._json,
           roles: ['authenticated']
         });
         user.save(function(err) {


### PR DESCRIPTION
This will fix LinkedIn login for second time via Passport