### PR TITLE
update gulp js path

### DIFF
--- a/gulp/development.js
+++ b/gulp/development.js
@@ -7,7 +7,7 @@ var gulp = require('gulp'),
   plugins = gulpLoadPlugins(),
   coffee = require('gulp-coffee'),
   paths = {
-    js: ['./*.js', 'config/**/*.js', 'gulp/**/*.js', 'tools/**/*.js', 'packages/**/*.js', '!packages/**/node_modules/**', '!packages/**/assets/**/lib/**'],
+    js: ['./*.js', 'config/**/*.js', 'gulp/**/*.js', 'tools/**/*.js', 'packages/**/*.js', '!packages/**/node_modules/**', '!packages/**/assets/**/lib/**', '!packages/**/assets/**/js/**'],
     html: ['packages/**/*.html', '!packages/**/node_modules/**', '!packages/**/assets/**/lib/**'],
     css: ['packages/**/*.css', '!packages/**/node_modules/**', '!packages/**/assets/**/lib/**'],
     less: ['packages/**/*.less', '!packages/**/node_modules/**', '!packages/**/assets/**/lib/**'],


### PR DESCRIPTION
ignore (swagger package libs) swagger-ui libs with jshint and if any package will use js folder inside assets for his private dependencies some packages like (Admin) uses assets/lib/ there for come '!packages/**/assets/**/lib/**' to ignore them too