### PR TITLE
Fix to allow unit tests to run through Gulp

### DIFF
--- a/gulp/test.js
+++ b/gulp/test.js
@@ -19,11 +19,11 @@ gulp.task('karma:unit', function (done) {
 
 gulp.task('loadTestSchema', function () {
   require('../server.js');
-  require('../node_modules/meanio/lib/core_modules/module/util').preload('../packages/**/server', 'model');
+  require('../node_modules/meanio/lib/core_modules/module/util').preload('./packages/**/server', 'model');
 });
 
 gulp.task('mochaTest', ['loadTestSchema'], function () {
-  return gulp.src('../packages/**/server/tests/**/*.js', {read: false})
+  return gulp.src('./packages/**/server/tests/**/*.js', {read: false})
     .pipe(plugins.mocha({
       reporter: 'spec'
     }));


### PR DESCRIPTION
As pointed out in this SO question:
http://stackoverflow.com/questions/29444270/mean-io-unit-tests-dont-run

The unit tests are not running properly for mean. This is part of the identified fix from SO.
There will be a separate PR against meanio for the second part of the fix:
linnovate/meanio#71

With these changes gulp test will run the mocha and karma unit tests. They all pass, though the only karma test suite is commented out.