### PR TITLE
Added optional favicon path lookup in config

### DIFF
--- a/packages/core/system/app.js
+++ b/packages/core/system/app.js
@@ -29,7 +29,11 @@ SystemPackage.register(function(app, auth, database, circles) {
   app.set('views', __dirname + '/server/views');
 
   // Setting the favicon and static folder
-  app.use(favicon(__dirname + '/public/assets/img/favicon.ico'));
+  if(config.favicon) {
+    app.use(favicon(config.favicon));
+  } else {
+    app.use(favicon(__dirname + '/public/assets/img/favicon.ico'));
+  }
 
   // Adding robots and humans txt
   app.useStatic(__dirname + '/public/assets/static');


### PR DESCRIPTION
This allows the default favicon to be overridden in all.js (or any env config) with a line like:
  favicon: rootPath + '/packages/custom/myPackage/public/assets/img/favicon.ico',
