### PR TITLE
Fixed issue https://github.com/linnovate/mean/issues/1169

### DIFF
--- a/config/env/all.js
+++ b/config/env/all.js
@@ -53,5 +53,10 @@ module.exports = {
     cssFramework: 'bootstrap'
   },
   // The session cookie name
-  sessionName: 'connect.sid'
+  sessionName: 'connect.sid',
+  // Set bodyParser options
+  bodyParser: {
+    json: {limit: '100kb'},
+    urlencoded: {limit: '100kb', extended: true}
+  }
 };

--- a/config/express.js
+++ b/config/express.js
@@ -13,9 +13,13 @@ var mean = require('meanio'),
   flash = require('connect-flash'),
   modRewrite = require('connect-modrewrite'),
   // seo = require('mean-seo'),
-  config = mean.loadConfig();
+  config = mean.loadConfig(),
+  bodyParser = require('body-parser');
 
 module.exports = function(app, db) {
+
+  app.use(bodyParser.json(config.bodyParser.json));
+  app.use(bodyParser.urlencoded(config.bodyParser.urlencoded));
 
   app.set('showStackError', true);
 


### PR DESCRIPTION
Fixed the issue https://github.com/linnovate/mean/issues/1169. Where an error is throw about request entity been too large.

Added an enhancement to enable setting body size in the mean configuration.