### PR TITLE
Server promise

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -6392,6 +6392,11 @@
         }
       }
     },
+    "q": {
+      "version": "1.4.1",
+      "from": "q@latest",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz"
+    },
     "request": {
       "version": "2.60.0",
       "from": "https://registry.npmjs.org/request/-/request-2.60.0.tgz",

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "passport-local": "latest",
     "passport-twitter": "latest",
     "request": "latest",
+    "q": "latest",
     "serve-favicon": "latest",
     "shelljs": "latest",
     "swig": "latest",

--- a/server.js
+++ b/server.js
@@ -11,6 +11,7 @@ console.log = function(){
 // Requires meanio .
 var mean = require('meanio');
 var cluster = require('cluster');
+var deferred = require('q').defer();
 
 
 // Code to run if we're in the master process or if we are not in debug mode/ running tests
@@ -50,7 +51,11 @@ if ((cluster.isMaster) &&
 // Creates and serves mean application
     mean.serve({ workerid: workerId /* more options placeholder*/ }, function (app) {
       var config = app.config.clean;
-        var port = config.https && config.https.port ? config.https.port : config.http.port;
-        console.log('Mean app started on port ' + port + ' (' + process.env.NODE_ENV + ') cluster.worker.id:', workerId);
+      var port = config.https && config.https.port ? config.https.port : config.http.port;
+      console.log('Mean app started on port ' + port + ' (' + process.env.NODE_ENV + ') cluster.worker.id:', workerId);
+
+      deferred.resolve(app);
     });
 }
+
+module.exports = deferred.promise;


### PR DESCRIPTION
Uses a Q based promise to signal when the server is ready, based on using require to start the server.
This is especially important in setting up testing environments.
Has no effect on launching the server via gulp as normal.