### PR TITLE
Fixes Gulp hang on error

### DIFF
--- a/gulp/test.js
+++ b/gulp/test.js
@@ -25,7 +25,7 @@ gulp.task('runMocha', ['startServer'], function () {
       reporter: 'spec'
     }))
     .on('error', function(error){
-      console.error(errro);
+      console.error(error);
       this.emit('end');
     });
 });

--- a/gulp/test.js
+++ b/gulp/test.js
@@ -23,7 +23,11 @@ gulp.task('runMocha', ['startServer'], function () {
   return gulp.src('./packages/**/server/tests/**/*.spec.js', {read: false})
     .pipe(plugins.mocha({
       reporter: 'spec'
-    }));
+    }))
+    .on('error', function(error){
+      console.error(errro);
+      this.emit('end');
+    });
 });
 gulp.task('runKarma', ['runMocha'], function (done) {
   request('http://localhost:3001/api/aggregatedassets', function(error, response, body) {


### PR DESCRIPTION
Gulp hangs if any of the Mocha server side tests error out. This causes it to report the error, but continue with other tasks. Especially important because the server will not shut down otherwise.