### PR TITLE
remove unused logout link in system and in the state provider

### DIFF
--- a/packages/core/system/app.js
+++ b/packages/core/system/app.js
@@ -38,14 +38,6 @@ SystemPackage.register(function(app, auth, database, circles) {
   // Adding robots and humans txt
   app.useStatic(__dirname + '/public/assets/static');
 
-  SystemPackage.menus.add({
-    title: 'Log Out',
-    link: 'Log Out',
-    roles: ['authenticated'],
-    menu: 'account'
-  });
-  
-
   return SystemPackage;
 
 });

--- a/packages/core/system/public/routes/system.js
+++ b/packages/core/system/public/routes/system.js
@@ -58,13 +58,6 @@ angular.module('mean.system').config(['$meanStateProvider', '$urlRouterProvider'
         url: '/',
         templateUrl: 'system/views/index.html'
       });
-
-    $meanStateProvider
-      .state('Log Out', {
-        controller: function () {
-          window.location = '/logout';
-        }
-      });
   }
 ]).config(['$locationProvider',
   function($locationProvider) {


### PR DESCRIPTION
This logout doesn't do anything as the account menu isn't in the account drop down at the moment.

Once the account dropdown is activated, a 2nd logout link appears that is non-functional.

I have removed that logout link