### PR TITLE
gulp less output path fix

### DIFF
--- a/gulp/development.js
+++ b/gulp/development.js
@@ -40,9 +40,7 @@ gulp.task('csslint', function () {
 gulp.task('less', function() {
   return gulp.src(paths.less)
     .pipe(plugins.less())
-    .pipe(gulp.dest(function (vinylFile) {
-      return vinylFile.cwd;
-    }));
+    .pipe(gulp.dest('./packages'));
 });
 
 gulp.task('devServe', ['env:development'], function () {


### PR DESCRIPTION
Current path is targeting invalid root path and creates there package named directories.