### PR TITLE
Replace content header margin with translate

### DIFF
--- a/packages/core/system/public/assets/css/common.css
+++ b/packages/core/system/public/assets/css/common.css
@@ -24,7 +24,7 @@
     margin-left: 0
 }
 .content {
-    margin-top: 70px;
+    transform: translateY(70px);
     width: 100%
 }
 footer {


### PR DESCRIPTION
Using translate instead of margin keeps the page from allowing scroll even when the contents are too small to require it.
