### PR TITLE
profileFields[] added to facebook strategy

### DIFF
--- a/packages/core/users/passport.js
+++ b/packages/core/users/passport.js
@@ -92,7 +92,8 @@ module.exports = function(passport) {
   passport.use(new FacebookStrategy({
       clientID: config.strategies.facebook.clientID,
       clientSecret: config.strategies.facebook.clientSecret,
-      callbackURL: config.strategies.facebook.callbackURL
+      callbackURL: config.strategies.facebook.callbackURL,
+      profileFields: ['id', 'displayName', 'emails']
     },
     function(accessToken, refreshToken, profile, done) {
       User.findOne({


### PR DESCRIPTION
profileFields need to be defined before requesting data from Facebook to ensure that the necessary data is returned.
Facebook have updated their web app and now some data is not returned by default, ie emails.