### PR TITLE
Adds new Bootswatch API support

### DIFF
--- a/packages/core/admin/public/controllers/themes.js
+++ b/packages/core/admin/public/controllers/themes.js
@@ -8,7 +8,7 @@ angular.module('mean.admin').controller('ThemesController', ['$scope', 'Global',
         $scope.init = function() {
             $http({
                 method: 'GET',
-                url: 'http://api.bootswatch.com/3/',
+                url: 'https://bootswatch.com/api/3.json',
                 skipAuthorization: true
             }).
             success(function(data, status, headers, config) {


### PR DESCRIPTION
The old Bootswatch API will be removed on December 16th, 2015. This
accesses the new one instead. See the [Bootswatch post]
(http://news.bootswatch.com/post/131219814698/changes-to-bootswatch-api) and [the issue](https://github.com/linnovate/mean/issues/1415)