### PR TITLE
CPU count can be configured with CPU_COUNT env var

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ if ((cluster.isMaster) &&
 
     console.log('for real!');
     // Count the machine's CPUs
-    var cpuCount = require('os').cpus().length;
+    var cpuCount = process.env.CPU_COUNT || require('os').cpus().length;
 
     // Create a worker for each CPU
     for (var i = 0; i < cpuCount; i += 1) {


### PR DESCRIPTION
Fixes https://github.com/linnovate/mean/issues/1451

Example:
`export CPU_COUNT=2`

bash:
```
echo 'export CPU_COUNT=2' >> ~/.bashrc
source ~/.bashrc
```

zsh:
```
echo 'export CPU_COUNT=2' >> ~/.zshrc
source ~/.zshrc
```