### PR TITLE
Fixes for heroku production site

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -37,7 +37,7 @@ $ sudo apt-get install nodejs
 ```
 $ npm install -g gulp
 // and bower
-$ npm install -g bower 
+$ npm install -g bower
 ```
 
 ## Installation
@@ -54,7 +54,7 @@ $ cd <myApp> && npm install
 
 ### Invoke node with a task manager
 Mean supports the gulp task runner for various services which are applied on the code.
-To start your application run - 
+To start your application run -
 ```bash
 $ gulp
 ```
@@ -275,7 +275,7 @@ All of the Server side code resides in the `/server` directory.
 
 All of the Client side code resides in the `/public` directory.
 
-    public            
+    public
     --- assets        # JavaScript/CSS/Images (not aggregated)
     --- controllers   # Angular controllers
     --- config        # Contains routing files
@@ -318,7 +318,7 @@ MEAN has 3 pre registered dependencies:
 Dependency injection allows you to declare what dependencies you require and rely on the package system to resolve all dependencies for you. Any package registered is automatically made available to anyone who would like to depend on them.
 
 Looking again at the registration example we can see that `MyPackage` depends on the `Tokens` package and can make use of its full functionality, including overriding it.
- 
+
 ```javascript
 // Example of registering the tokens package
 MyPackage.register(function(app, auth, database, Tokens) {
@@ -389,7 +389,7 @@ MyPackage.aggregateAsset('js','first.js',{global:true,  weight: -4, group: 'head
 The settings object is a persistence object that is stored in the packages collection and allows for saving persistent information per package such as configuration options or admin settings for the package.
 
   Receives two arguments the first being the settings object the second is a callback function
-  
+
 ```javascript
 MyPackage.settings({'someSetting':'some value'}, function (err, settings) {
     // You will receive the settings object on success
@@ -529,7 +529,7 @@ Where "myPackage" is the name of your package.
 Once your package is in good shape and you want to share it with the world you can start the process of contributing it and submiting it so it can be included in the package repository.
 To contribute your package register to the network (see the section below) and run
 
-```bash 
+```bash
 $ mean register # register to the mean network (see below)
 $ cd <packages/custom/pkgName>
 $ mean publish
@@ -634,7 +634,7 @@ The production uses the widely used [combined format](https://github.com/express
 ```
 
 ## Staying up to date
-After initializing a project, you'll see that the root directory of your project is already a git repository. MEAN uses git to download and update its own code. To handle its own operations, MEAN creates a remote called `upstream`. This way you can use git as you would in any other project. 
+After initializing a project, you'll see that the root directory of your project is already a git repository. MEAN uses git to download and update its own code. To handle its own operations, MEAN creates a remote called `upstream`. This way you can use git as you would in any other project.
 
 To update your MEAN app to the latest version of MEAN
 
@@ -668,15 +668,30 @@ which has an easy setup).
 
 Add the db string to the production env in *server/config/env/production.js*.
 
+Create heroku app (if needed)
 ```bash
 $ git init
 $ git add .
 $ git commit -m "initial version"
+
 $ heroku apps:create
-$ heroku config:add NODE_ENV=production
-$ git push heroku master
-$ heroku config:set NODE_ENV=production
 ```
+
+If you get missing module errors, install missing dependencies
+```
+npm i -S ms kerberos
+npm update --save
+git commit -m "save versions to package.json"
+```
+
+Push to heroku and configure
+```
+$ git push heroku master
+$ heroku config:set NODE_MODULES_CACHE=false
+$ heroku config:set NODE_ENV=production
+$ heroku config:set CPU_COUNT=2
+```
+You can adjust the CPU_COUNT variable up or down based on how much memory your app is consuming, or leave it unset to fork a process for each CPU.
 
 ### OpenShift
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -266,7 +266,7 @@
           "dependencies": {
             "inherits": {
               "version": "2.0.1",
-              "from": "inherits@>=2.0.0 <3.0.0",
+              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
             },
             "statuses": {
@@ -2108,6 +2108,18 @@
       "from": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz",
       "resolved": "https://registry.npmjs.org/connect-flash/-/connect-flash-0.1.1.tgz"
     },
+    "connect-modrewrite": {
+      "version": "0.8.2",
+      "from": "connect-modrewrite@latest",
+      "resolved": "https://registry.npmjs.org/connect-modrewrite/-/connect-modrewrite-0.8.2.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "1.2.2",
+          "from": "qs@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+        }
+      }
+    },
     "consolidate": {
       "version": "0.13.1",
       "from": "https://registry.npmjs.org/consolidate/-/consolidate-0.13.1.tgz",
@@ -2340,7 +2352,7 @@
               "dependencies": {
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
@@ -4036,7 +4048,7 @@
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+              "from": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
               "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
             },
             "mime-types": {
@@ -4497,86 +4509,86 @@
     },
     "mongoose": {
       "version": "4.3.3",
-      "from": "mongoose@latest",
+      "from": "https://registry.npmjs.org/mongoose/-/mongoose-4.3.3.tgz",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.3.3.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@0.9.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "bson": {
           "version": "0.4.19",
-          "from": "bson@0.4.19",
+          "from": "https://registry.npmjs.org/bson/-/bson-0.4.19.tgz",
           "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.19.tgz"
         },
         "hooks-fixed": {
           "version": "1.1.0",
-          "from": "hooks-fixed@1.1.0",
+          "from": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz",
           "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-1.1.0.tgz"
         },
         "kareem": {
           "version": "1.0.1",
-          "from": "kareem@1.0.1",
+          "from": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz",
           "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.0.1.tgz"
         },
         "mongodb": {
           "version": "2.1.0",
-          "from": "mongodb@2.1.0",
+          "from": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.0.tgz",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.0.tgz",
           "dependencies": {
             "mongodb-core": {
               "version": "1.2.26",
-              "from": "mongodb-core@1.2.26",
+              "from": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.26.tgz",
               "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.2.26.tgz",
               "dependencies": {
                 "bson": {
                   "version": "0.4.20",
-                  "from": "bson@>=0.4.20 <0.5.0",
+                  "from": "https://registry.npmjs.org/bson/-/bson-0.4.20.tgz",
                   "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.20.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.0.31",
-              "from": "readable-stream@1.0.31",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "es6-promise": {
               "version": "3.0.2",
-              "from": "es6-promise@3.0.2",
+              "from": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
               "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
             },
             "kerberos": {
               "version": "0.0.17",
-              "from": "kerberos@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.17.tgz",
               "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.17.tgz",
               "dependencies": {
                 "nan": {
                   "version": "2.0.9",
-                  "from": "nan@>=2.0.0 <2.1.0",
+                  "from": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.0.9.tgz"
                 }
               }
@@ -4585,44 +4597,44 @@
         },
         "mpath": {
           "version": "0.1.1",
-          "from": "mpath@0.1.1",
+          "from": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz",
           "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
         },
         "mpromise": {
           "version": "0.5.4",
-          "from": "mpromise@0.5.4",
+          "from": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz",
           "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.4.tgz"
         },
         "mquery": {
           "version": "1.6.3",
-          "from": "mquery@1.6.3",
+          "from": "https://registry.npmjs.org/mquery/-/mquery-1.6.3.tgz",
           "resolved": "https://registry.npmjs.org/mquery/-/mquery-1.6.3.tgz",
           "dependencies": {
             "bluebird": {
               "version": "2.9.26",
-              "from": "bluebird@2.9.26",
+              "from": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz",
               "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
             },
             "debug": {
               "version": "2.2.0",
-              "from": "debug@2.2.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz"
             }
           }
         },
         "muri": {
           "version": "1.0.0",
-          "from": "muri@1.0.0",
+          "from": "https://registry.npmjs.org/muri/-/muri-1.0.0.tgz",
           "resolved": "https://registry.npmjs.org/muri/-/muri-1.0.0.tgz"
         },
         "regexp-clone": {
           "version": "0.0.1",
-          "from": "regexp-clone@0.0.1",
+          "from": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
         },
         "sliced": {
           "version": "0.0.5",
-          "from": "sliced@0.0.5",
+          "from": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
           "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
         }
       }
@@ -6245,7 +6257,7 @@
             },
             "mkdirp": {
               "version": "0.5.1",
-              "from": "mkdirp@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
               "dependencies": {
                 "minimist": {

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "body-parser": "latest",
     "compression": "latest",
     "connect-flash": "latest",
+    "connect-modrewrite": "latest",
     "consolidate": "latest",
     "cookie-parser": "latest",
     "errorhandler": "latest",
@@ -54,7 +55,6 @@
     "view-helpers": "latest"
   },
   "devDependencies": {
-    "connect-modrewrite": "latest",
     "del": "latest",
     "expect.js": "latest",
     "gulp": "latest",


### PR DESCRIPTION
- Moves connect-modrewrite to dependencies instead of devDependencies for heroku  and other environments that do not install `devDependencies` when `NODE_ENV=production`
- Updates heroku instructions in Readme
- Regenned npm-shrinkwrap