### PR TITLE
Fixing the admin settings save process

### DIFF
--- a/packages/core/admin/public/controllers/settings.js
+++ b/packages/core/admin/public/controllers/settings.js
@@ -18,12 +18,12 @@ angular.module('mean.admin').controller('SettingsController', ['$scope', 'Global
         };
 
         $scope.update = function(settings) {
-            settings = JSON.clean(JSON.unflatten(settings));
+            settings = JSON.unflatten(JSON.clean(settings));
             Settings.update(settings, function(data) {});
         };
 
         $scope.getTextToCopy = function() {
-            var settings = JSON.clean(JSON.unflatten($scope.settings));
+            var settings = JSON.unflatten(JSON.clean($scope.settings));
             return JSON.stringify(settings);
         };
 

--- a/packages/core/system/public/views/header.html
+++ b/packages/core/system/public/views/header.html
@@ -12,7 +12,7 @@
             </div>
         </div>
 
-        <div class="collapse navbar-collapse" ng-class="!isCollapsed && 'in'">
+        <div class="collapse navbar-collapse" ng-class="isCollapsed && 'in'">
             <div class="left pull-left">
                 <ul class="navbar-nav nav">
                     <li ui-route="/{{item.link}}" ng-class="{active: $uiRoute}" ng-repeat="item in hdrctr.menus.main">


### PR DESCRIPTION
The filter from ui dataset to database compatible version was reversed and coming out wrong and every time it saved to the database it would cause catastrophic failures.  This should fix the fundamental act of saving.
