### PR TITLE
$rootScope loggedin event emits userObj

### DIFF
--- a/packages/core/users/public/services/meanUser.js
+++ b/packages/core/users/public/services/meanUser.js
@@ -52,7 +52,7 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
       $http.get('/api/users/me').success(function(response) {
         if(!response && $cookies.get('token') && $cookies.get('redirect')) {
           self.onIdentity.bind(self)({
-            token: $cookies.get('token'), 
+            token: $cookies.get('token'),
             redirect: $cookies.get('redirect').replace(/^"|"$/g, '')
           });
           $cookies.remove('token');
@@ -84,7 +84,7 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
       if (angular.isDefined(response.token)) {
         localStorage.setItem('JWT', response.token);
         encodedUser = decodeURI(b64_to_utf8(response.token.split('.')[1]));
-        user = JSON.parse(encodedUser); 
+        user = JSON.parse(encodedUser);
       }
       destination = angular.isDefined(response.redirect) ? response.redirect : destination;
       $cookies.remove('redirect');
@@ -93,6 +93,7 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
       this.loginError = 0;
       this.registerError = 0;
       this.isAdmin = this.user.roles.indexOf('admin') > -1;
+      var userObj = this.user;
       // Add circles info to user
       $http.get('/api/circles/mine').success(function(acl) {
         if(self.aclDefer) {
@@ -103,7 +104,7 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
         if (destination) {
           $location.path(destination);
         }
-        $rootScope.$emit('loggedin');
+        $rootScope.$emit('loggedin', userObj);
       });
     };
 


### PR DESCRIPTION
Since Global service doesn't work as anticipated, this is an easy way to get the logged in user. To consume:

```
$rootScope.$on('loggedin', doStuff);

function doStuff(event, data) {
  console.log(data);
}
```