### PR TITLE
Bump snyk dependency to ^1.17.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "q": "latest",
     "request": "latest",
     "shelljs": "latest",
-    "snyk": "1.16.0",
+    "snyk": "^1.17.1",
     "view-helpers": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
1.16.0 has a bug preventing patches being applied on Windows (patch-related file has ':' in filename)