### PR TITLE
Fix angular 1.6.0 breaks

### DIFF
--- a/packages/core/admin/public/services/module-settings.js
+++ b/packages/core/admin/public/services/module-settings.js
@@ -5,35 +5,35 @@ angular.module('mean.admin').factory('ModuleSettings', ['$http', '$q',
 			get: function(name) {
 				var deferred = $q.defer();
 				$http.get('/api/admin/moduleSettings/' + name)
-					.success(function(data) {
-						deferred.resolve(data);
+					.then(function(response) {
+						deferred.resolve(response.data);
 					})
-					.error(function(data) {
-						deferred.reject(data);
+					.catch(function(response) {
+						deferred.reject(response.data);
 					});
 				return deferred.promise;
 			},
 			update: function(name, data) {
 				var deferred = $q.defer();
 				$http.put('/api/admin/moduleSettings/' + name, data)
-					.success(function(data) {
-						deferred.resolve(data);
-					})
-					.error(function(data) {
-						deferred.reject(data);
-					});
-				return deferred.promise;
+          .then(function(response) {
+            deferred.resolve(response.data);
+          })
+          .catch(function(response) {
+            deferred.reject(response.data);
+          });
+        return deferred.promise;
 			},
 			save: function(name, data) {
 				var deferred = $q.defer();
 				$http.post('/api/admin/moduleSettings/' + name, data)
-					.success(function(data) {
-						deferred.resolve(data);
-					})
-					.error(function(data) {
-						deferred.reject(data);
-					});
-				return deferred.promise;
+          .then(function(response) {
+            deferred.resolve(response.data);
+          })
+          .catch(function(response) {
+            deferred.reject(response.data);
+          });
+        return deferred.promise;
 			}
 		};
 	}

--- a/packages/core/admin/public/services/modules.js
+++ b/packages/core/admin/public/services/modules.js
@@ -4,8 +4,8 @@ angular.module('mean.admin').factory('Modules', ['$http',
         return {
             get: function(callback) {
                 $http.get('/api/admin/modules')
-                    .success(function(data) {
-                        callback(data);
+                    .then(function(response) {
+                        callback(response.data);
                     });
             }
         };

--- a/packages/core/admin/public/services/settings.js
+++ b/packages/core/admin/public/services/settings.js
@@ -4,24 +4,25 @@ angular.module('mean.admin').factory('Settings', ['$http',
     function($http) {
         var get = function(callback) {
         // Temporary - probably it should to be resource based.
-            $http.get('/api/admin/settings').success(function(data, status, headers, config) {
+            $http.get('/api/admin/settings').then(function(response) {
+                var data = response.data;
                 callback({
                     success: true,
                     settings: data
                 });
             }).
-            error(function(data, status, headers, config) {
+            catch(function(response) {
                 callback({
                     success: false
                 });
             });
         };
         var update = function(settings, callback) {
-            $http.put('/api/admin/settings', settings).success(function(data, status, headers, config) {
-                callback(data);
+            $http.put('/api/admin/settings', settings).then(function(response) {
+                callback(response.data);
             }).
-            error(function(data, status, headers, config) {
-                callback(data);
+            error(function(response) {
+                callback(response.data);
             });
         };
         return {

--- a/packages/core/users/public/controllers/meanUser.js
+++ b/packages/core/users/public/controllers/meanUser.js
@@ -9,7 +9,8 @@ angular.module('mean.users')
       $scope.$state = $state;
 
       $http.get('/api/get-config')
-        .success(function(config) {
+        .then(function(response) {
+          var config = response.data;
           if(config.hasOwnProperty('local')) delete config.local; // Only non-local passport strategies
           $scope.socialButtons = config;
           $scope.socialButtonsCounter = Object.keys(config).length;
@@ -22,7 +23,7 @@ angular.module('mean.users')
 
       // This object will be filled by the form
       vm.user = {};
-      
+
       vm.input = {
         type: 'password',
         placeholder: 'Password',
@@ -53,7 +54,7 @@ angular.module('mean.users')
       var vm = this;
 
       vm.user = {};
-      
+
       vm.registerForm = MeanUser.registerForm = true;
 
       vm.input = {
@@ -91,7 +92,7 @@ angular.module('mean.users')
   .controller('ForgotPasswordCtrl', ['MeanUser', '$rootScope',
     function(MeanUser, $rootScope) {
       var vm = this;
-      vm.user = {};      
+      vm.user = {};
       vm.registerForm = MeanUser.registerForm = false;
       vm.forgotpassword = function() {
         MeanUser.forgotpassword(this.user);
@@ -104,7 +105,7 @@ angular.module('mean.users')
   .controller('ResetPasswordCtrl', ['MeanUser',
     function(MeanUser) {
       var vm = this;
-      vm.user = {};      
+      vm.user = {};
       vm.registerForm = MeanUser.registerForm = false;
       vm.resetpassword = function() {
         MeanUser.resetpassword(this.user);

--- a/packages/core/users/public/services/meanUser.js
+++ b/packages/core/users/public/services/meanUser.js
@@ -132,10 +132,10 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
           redirect: $cookies.get('redirect') || destination
         })
         .then(function (response){
-          self.onIdentity.bind(self)
+          self.onIdentity.bind(self);
         })
         .catch(function (response){
-          self.onIdFail.bind(self)
+          self.onIdFail.bind(self);
         });
     };
 
@@ -149,10 +149,10 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
         name: user.name
       })
         .then(function (response){
-          self.onIdentity.bind(self)
+          self.onIdentity.bind(self);
         })
         .catch(function (response){
-          self.onIdFail.bind(self)
+          self.onIdFail.bind(self);
         });
     };
 
@@ -163,10 +163,10 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
         confirmPassword: user.confirmPassword
       })
         .then(function (response){
-          self.onIdentity.bind(self)
+          self.onIdentity.bind(self);
         })
         .catch(function (response){
-          self.onIdFail.bind(self)
+          self.onIdFail.bind(self);
         });
       };
 

--- a/packages/core/users/public/services/meanUser.js
+++ b/packages/core/users/public/services/meanUser.js
@@ -179,7 +179,7 @@ angular.module('mean.users').factory('MeanUser', [ '$rootScope', '$http', '$loca
           $rootScope.$emit('forgotmailsent', response.data);
         })
         .catch(function (response){
-          self.onIdFail.bind(self)
+          self.onIdFail.bind(self);
         });
       };
 


### PR DESCRIPTION
`$http(...).success` and `$http(...).error` have been removed.
`$http(...).then`and `$http(...).catch`used instead as suggested at :
https://docs.angularjs.org/guide/migration#migrate1.5to1.6-ng-services-$http