### PR TITLE
Missing indentation in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,21 +1,21 @@
 version: "2"
 services:
-lager-server:
-build:
-context: .
-dockerfile: Dockerfile
-command: npm start
-depends_on:
-- mongodb
-volumes:
-- .:/src
-- /node_modules
-ports:
-- 80:3000
-links:
-- mongodb
-mongodb:
-image: mongo:latest
-command: --smallfiles
-ports:
-- 27017:27017
+  lager-server:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    command: npm start
+    depends_on:
+      - mongodb
+    volumes:
+      - .:/src
+      - /node_modules
+    ports:
+      - 80:3000
+    links:
+      - mongodb
+  mongodb:
+    image: mongo:latest
+    command: --smallfiles
+    ports:
+      - 27017:27017


### PR DESCRIPTION
'docker-compose up' will break without indentation

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Getting an error:
ERROR: In file './docker-compose.yml', service must be a mapping, not a NoneType.



* **What is the new behavior (if this is a feature change)?**

No error

* **Other information**:
This is the reference on why this change is necessary 
http://yaml.org/spec/1.2/spec.html#id2777534
