### PR TITLE
Updated concurrently syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "ng": "ng",
     "serve": "node server",
-    "start": "concurrently -c 'yellow.bold,green.bold' -n 'SERVER,BUILD' 'nodemon server' 'ng build --watch'",
+    "start": "concurrently -c \"yellow.bold,green.bold\" -n \"SERVER,BUILD\" \"nodemon server\" \"ng build --watch\"",
     "build": "ng build --prod",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
The concurrently documentation suggests using escaped double quotes when defining package.json scripts. I suspect this will fix the problems faced by some users when executing `yarn start`