### PR TITLE
fix: Angular admin routing path

### DIFF
--- a/src/app/admin/admin-routing.module.ts
+++ b/src/app/admin/admin-routing.module.ts
@@ -6,7 +6,7 @@ import { OnlyAdminUsersGuard } from './admin-user-guard';
 
 const routes: Routes = [
   {
-    path: 'admin',
+    path: '',
     canActivate: [OnlyAdminUsersGuard],
     children: [
       {


### PR DESCRIPTION
The admin path was already declared in the app-routing routes declaration.