### PR TITLE
Add Kubernetes Deployment, Service, and HPA Manifests for Frontend and Database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.18-alpine
+FROM node:18.17.1-alpine
 
 WORKDIR /usr/src/app
 COPY . /usr/src/app

--- a/k8s/app/deployment.yaml
+++ b/k8s/app/deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1 
+kind: Deployment 
+metadata: 
+  name: angular-app 
+spec: 
+  replicas: 1
+  selector:
+    matchLabels:
+      app: angular-app
+  template: 
+    metadata:
+      labels:
+        app: angular-app
+    spec: 
+      containers:
+        - name: angular-app
+          image: sharmaaakash170/angular-app:latest 
+          ports:
+            - containerPort: 4040 
+          resources: 
+            requests:
+              cpu: "100m" 
+              memory: "128Mi"
+            limits:
+              cpu: "200m" 
+              memory: "256Mi"
+          env: 
+            - name: SERVER_PORT
+              value: "4040"
+            - name: "NODE_ENV"
+              value: "production" 
+            - name: JWT_SECRET
+              value: "0a6b944d-d2fb-46fc-a85e-0295c986cd9f"
+            - name: MONGO_HOST
+              value: mongodb://mongo-service.default.svc.cluster.local:27017/mean
+          imagePullPolicy: IfNotPresent
+          

--- a/k8s/app/hpa.yaml
+++ b/k8s/app/hpa.yaml
@@ -1,0 +1,18 @@
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: backend-hpa
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: angular-app 
+  minReplicas: 2
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 60

--- a/k8s/app/service.yaml
+++ b/k8s/app/service.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1 
+kind: Service 
+metadata: 
+  name: angular-app-service 
+spec: 
+  selector:
+    app: angular-app
+  ports: 
+    - port: 4040
+      targetPort: 4040

--- a/k8s/db/deployment.yaml
+++ b/k8s/db/deployment.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1 
+kind: Deployment
+metadata: 
+  name: mongo
+spec: 
+  replicas: 1
+  selector:
+    matchLabels: 
+      app: mongo
+  template: 
+    metadata:
+      labels:
+        app: mongo 
+    spec: 
+      containers: 
+        - name: mongo 
+          image: mongo:4.2 
+          ports:
+            - containerPort: 27017 
+          volumeMounts:
+            - name: mongo-persistent-storage 
+              mountPath: /data/db 
+      volumes: 
+        - name: mongo-persistent-storage
+          persistentVolumeClaim: 
+            claimName: mongo-pvc

--- a/k8s/db/mongo-pv.yaml
+++ b/k8s/db/mongo-pv.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1 
+kind: PersistentVolume 
+metadata: 
+  name: mongo-pv 
+spec: 
+  capacity:
+    storage: 1Gi
+  accessModes: 
+    - ReadWriteOnce 
+  hostPath:
+    path: "/mnt/data/mongo" 
+  persistentVolumeReclaimPolicy: Retain 

--- a/k8s/db/mongo-pvc.yaml
+++ b/k8s/db/mongo-pvc.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: PersistentVolumeClaim 
+metadata: 
+  name: mongo-pvc 
+spec: 
+  volumeName: mongo-pv 
+  accessModes: 
+    - ReadWriteOnce 
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: "" 

--- a/k8s/db/service.yaml
+++ b/k8s/db/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1 
+kind: Service 
+metadata: 
+  name: mongo-service 
+spec: 
+  selector:
+    app: mongo
+  ports:
+    - port: 27017
+      targetPort: 27017
+      protocol: TCP
+  

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,5 +1,9 @@
 {
   "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/app",
+    "types": []
+  },
   "files": [
     "src/polyfills.ts",
     "src/main.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,6 @@
     "declaration": false,
     "importHelpers": true,
     "experimentalDecorators": true,
-    "suppressImplicitAnyIndexErrors": true,
     "useDefineForClassFields": false
   }
 }


### PR DESCRIPTION
### Summary

This PR introduces Kubernetes configuration files for the MEAN stack application, including:

- ✅ Deployment and Service manifests for the **frontend**.
- ✅ Deployment and Service manifests for the **MongoDB database**.
- ✅ Horizontal Pod Autoscaler (HPA) for the frontend for better scalability.

These configurations aim to make the application cloud-native, improving its portability and production-readiness.

### Benefits

- Supports container orchestration with Kubernetes.
- Enhances scalability and resource management with HPA.
- Lays the groundwork for CI/CD and infrastructure-as-code practices.

Looking forward to feedback and suggestions!
